### PR TITLE
feat: add endpoint to create syndic with files and manage mandates

### DIFF
--- a/src/main/java/com/app/copro/controller/MandatController.java
+++ b/src/main/java/com/app/copro/controller/MandatController.java
@@ -1,0 +1,74 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.dto.MandatDto;
+import com.app.copro.service.MandatFileService;
+import com.app.copro.service.MandatService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/syndics/{syndicId}/mandat")
+@CrossOrigin(origins = "*")
+public class MandatController {
+
+    private final MandatService mandatService;
+
+    @Autowired
+    private MandatFileService mandatFileService;
+
+    @Autowired
+    public MandatController(MandatService mandatService) {
+        this.mandatService = mandatService;
+    }
+
+    @PostMapping
+    public ResponseEntity<MandatDto> createMandat(@PathVariable Long syndicId,
+                                                  @Valid @RequestBody MandatDto mandatDto) {
+        MandatDto created = mandatService.createMandat(syndicId, mandatDto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<MandatDto> createMandatWithFile(@PathVariable Long syndicId,
+                                                          @RequestPart("mandat") @Valid MandatDto mandatDto,
+                                                          @RequestPart(value = "file", required = false) MultipartFile file) {
+        MandatDto created = mandatService.createMandat(syndicId, mandatDto);
+        if (file != null && !file.isEmpty()) {
+            String ref = mandatFileService.uploadMandatFile(syndicId, file);
+            created.setFichierRef(ref);
+        }
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<MandatDto> getMandat(@PathVariable Long syndicId) {
+        MandatDto dto = mandatService.getMandatBySyndic(syndicId);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping
+    public ResponseEntity<MandatDto> updateMandat(@PathVariable Long syndicId,
+                                                  @Valid @RequestBody MandatDto mandatDto) {
+        MandatDto updated = mandatService.updateMandat(syndicId, mandatDto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @PostMapping("/file")
+    public ResponseEntity<String> uploadMandatFile(@PathVariable Long syndicId,
+                                                   @RequestParam("file") MultipartFile file) {
+        String ref = mandatFileService.uploadMandatFile(syndicId, file);
+        return ref != null ? ResponseEntity.ok(ref) : ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/file")
+    public ResponseEntity<FileResponseDto> getMandatFile(@PathVariable Long syndicId) {
+        FileResponseDto file = mandatFileService.getMandatFile(syndicId);
+        return file != null ? ResponseEntity.ok(file) : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/app/copro/controller/SyndicController.java
+++ b/src/main/java/com/app/copro/controller/SyndicController.java
@@ -9,6 +9,7 @@ import com.app.copro.service.SyndicFileService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,6 +33,47 @@ public class SyndicController {
     @PostMapping
     public ResponseEntity<SyndicResponseDto> createSyndic(@Valid @RequestBody CreateSyndicDto createSyndicDto) {
         SyndicResponseDto response = syndicService.createSyndic(createSyndicDto);
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/with-files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<SyndicResponseDto> createSyndicWithFiles(
+            @RequestPart("syndic") @Valid CreateSyndicDto createSyndicDto,
+            @RequestPart(value = "docCarteProfessionnelle", required = false) MultipartFile docCarteProfessionnelle,
+            @RequestPart(value = "docAssuranceRc", required = false) MultipartFile docAssuranceRc,
+            @RequestPart(value = "docGarantieFinanciere", required = false) MultipartFile docGarantieFinanciere,
+            @RequestPart(value = "docTamponSignature", required = false) MultipartFile docTamponSignature,
+            @RequestPart(value = "logoCoordonnees", required = false) MultipartFile logoCoordonnees,
+            @RequestPart(value = "logoSimple", required = false) MultipartFile logoSimple
+    ) {
+        SyndicResponseDto response = syndicService.createSyndic(createSyndicDto);
+        Long syndicId = response.getId();
+
+        if (docCarteProfessionnelle != null) {
+            String ref = syndicFileService.uploadCarteProfessionnelle(syndicId, docCarteProfessionnelle);
+            response.setDocCarteProfessionnellePath(ref);
+        }
+        if (docAssuranceRc != null) {
+            String ref = syndicFileService.uploadAssuranceRc(syndicId, docAssuranceRc);
+            response.setDocAssuranceRcPath(ref);
+        }
+        if (docGarantieFinanciere != null) {
+            String ref = syndicFileService.uploadGarantieFinanciere(syndicId, docGarantieFinanciere);
+            response.setDocGarantieFinancierePath(ref);
+        }
+        if (docTamponSignature != null) {
+            String ref = syndicFileService.uploadTamponSignature(syndicId, docTamponSignature);
+            response.setDocTamponSignaturePath(ref);
+        }
+        if (logoCoordonnees != null) {
+            String ref = syndicFileService.uploadLogoCoordonnees(syndicId, logoCoordonnees);
+            response.setLogoCoordonneesPath(ref);
+        }
+        if (logoSimple != null) {
+            String ref = syndicFileService.uploadLogoSimple(syndicId, logoSimple);
+            response.setLogoSimplePath(ref);
+        }
+
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/app/copro/dto/MandatDto.java
+++ b/src/main/java/com/app/copro/dto/MandatDto.java
@@ -1,62 +1,29 @@
-package com.app.copro.model;
+package com.app.copro.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
-@Entity
-@Table(name = "mandat")
-public class Mandat {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+public class MandatDto {
     private Long id;
 
-    // N° mandat
-    @Column(nullable = false, length = 120)
+    @NotBlank
     private String numero;
 
-    // Dates
-    @Column(nullable = false)
+    @NotNull
     private LocalDate dateDebut;
 
-    @Column(nullable = false)
+    @NotNull
     private LocalDate dateFin;
 
     private LocalDate dateSignature;
-
-    // Type de mandat (ex: CONTRAT_SYNDIC)
-    @Column(length = 50)
     private String typeMandat;
-
-    // Administrateur provisoire
-    @Column(nullable = false)
-    private Boolean administrateurProvisoire = false;
-
-    // Adresse
-    @Column(length = 180)
+    private Boolean administrateurProvisoire;
     private String adresse;
-
-    @Column(length = 180)
     private String complement;
-
-    @Column(length = 20)
     private String codePostal;
-
-    @Column(length = 120)
     private String ville;
-
-    // Référence vers le fichier du mandat
-    @Column(length = 255)
     private String fichierRef;
-
-    // propriétaire de la relation 1–1
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "syndic_id", unique = true, nullable = false)
-    @JsonIgnore
-    private Syndic syndic;
-
-    // ===== Getters/Setters =====
 
     public Long getId() {
         return id;
@@ -153,12 +120,5 @@ public class Mandat {
     public void setFichierRef(String fichierRef) {
         this.fichierRef = fichierRef;
     }
-
-    public Syndic getSyndic() {
-        return syndic;
-    }
-
-    public void setSyndic(Syndic syndic) {
-        this.syndic = syndic;
-    }
 }
+

--- a/src/main/java/com/app/copro/exception/MandatNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/MandatNotFoundException.java
@@ -1,0 +1,7 @@
+package com.app.copro.exception;
+
+public class MandatNotFoundException extends RuntimeException {
+    public MandatNotFoundException(Long syndicId) {
+        super("Mandat not found for syndic id " + syndicId);
+    }
+}

--- a/src/main/java/com/app/copro/repository/MandatRepository.java
+++ b/src/main/java/com/app/copro/repository/MandatRepository.java
@@ -1,0 +1,9 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.Mandat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface MandatRepository extends JpaRepository<Mandat, Long> {
+    Optional<Mandat> findBySyndicId(Long syndicId);
+}

--- a/src/main/java/com/app/copro/service/MandatFileService.java
+++ b/src/main/java/com/app/copro/service/MandatFileService.java
@@ -1,0 +1,49 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.exception.MandatNotFoundException;
+import com.app.copro.model.Mandat;
+import com.app.copro.repository.MandatRepository;
+import com.app.copro.util.FileConstants;
+import com.app.copro.util.FileManagerHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+public class MandatFileService {
+
+    @Autowired
+    private FileManagerHelper fileManagerHelper;
+
+    @Autowired
+    private MandatRepository mandatRepository;
+
+    public String uploadMandatFile(Long syndicId, MultipartFile file) {
+        Mandat mandat = mandatRepository.findBySyndicId(syndicId)
+                .orElseThrow(() -> new MandatNotFoundException(syndicId));
+
+        String fileRef = fileManagerHelper.uploadEntityDocument(
+                file,
+                FileConstants.EntityTypes.MANDAT,
+                mandat.getId(),
+                FileConstants.CommonCategories.CONTRAT,
+                "Document de mandat"
+        );
+
+        if (fileRef != null) {
+            mandat.setFichierRef(fileRef);
+            mandatRepository.save(mandat);
+        }
+
+        return fileRef;
+    }
+
+    public FileResponseDto getMandatFile(Long syndicId) {
+        Optional<Mandat> mandatOpt = mandatRepository.findBySyndicId(syndicId);
+        return mandatOpt.map(m -> fileManagerHelper.parseFileReference(m.getFichierRef())).orElse(null);
+    }
+}
+

--- a/src/main/java/com/app/copro/service/MandatService.java
+++ b/src/main/java/com/app/copro/service/MandatService.java
@@ -1,0 +1,87 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.MandatDto;
+import com.app.copro.exception.MandatNotFoundException;
+import com.app.copro.exception.SyndicNotFoundException;
+import com.app.copro.model.Mandat;
+import com.app.copro.model.Syndic;
+import com.app.copro.repository.MandatRepository;
+import com.app.copro.repository.SyndicRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MandatService {
+
+    private final MandatRepository mandatRepository;
+    private final SyndicRepository syndicRepository;
+
+    @Autowired
+    public MandatService(MandatRepository mandatRepository, SyndicRepository syndicRepository) {
+        this.mandatRepository = mandatRepository;
+        this.syndicRepository = syndicRepository;
+    }
+
+    @Transactional
+    public MandatDto createMandat(Long syndicId, MandatDto dto) {
+        Syndic syndic = syndicRepository.findById(syndicId)
+                .orElseThrow(() -> new SyndicNotFoundException(syndicId));
+
+        if (mandatRepository.findBySyndicId(syndicId).isPresent()) {
+            throw new IllegalStateException("Mandat already exists for this syndic");
+        }
+
+        Mandat mandat = new Mandat();
+        applyDtoToEntity(dto, mandat);
+        mandat.setSyndic(syndic);
+        Mandat saved = mandatRepository.save(mandat);
+        return mapToDto(saved);
+    }
+
+    public MandatDto getMandatBySyndic(Long syndicId) {
+        Mandat mandat = mandatRepository.findBySyndicId(syndicId)
+                .orElseThrow(() -> new MandatNotFoundException(syndicId));
+        return mapToDto(mandat);
+    }
+
+    @Transactional
+    public MandatDto updateMandat(Long syndicId, MandatDto dto) {
+        Mandat mandat = mandatRepository.findBySyndicId(syndicId)
+                .orElseThrow(() -> new MandatNotFoundException(syndicId));
+        applyDtoToEntity(dto, mandat);
+        Mandat saved = mandatRepository.save(mandat);
+        return mapToDto(saved);
+    }
+
+    private MandatDto mapToDto(Mandat mandat) {
+        MandatDto dto = new MandatDto();
+        dto.setId(mandat.getId());
+        dto.setNumero(mandat.getNumero());
+        dto.setDateDebut(mandat.getDateDebut());
+        dto.setDateFin(mandat.getDateFin());
+        dto.setDateSignature(mandat.getDateSignature());
+        dto.setTypeMandat(mandat.getTypeMandat());
+        dto.setAdministrateurProvisoire(mandat.getAdministrateurProvisoire());
+        dto.setAdresse(mandat.getAdresse());
+        dto.setComplement(mandat.getComplement());
+        dto.setCodePostal(mandat.getCodePostal());
+        dto.setVille(mandat.getVille());
+        dto.setFichierRef(mandat.getFichierRef());
+        return dto;
+    }
+
+    private void applyDtoToEntity(MandatDto dto, Mandat mandat) {
+        mandat.setNumero(dto.getNumero());
+        mandat.setDateDebut(dto.getDateDebut());
+        mandat.setDateFin(dto.getDateFin());
+        mandat.setDateSignature(dto.getDateSignature());
+        mandat.setTypeMandat(dto.getTypeMandat());
+        mandat.setAdministrateurProvisoire(dto.getAdministrateurProvisoire() != null ? dto.getAdministrateurProvisoire() : false);
+        mandat.setAdresse(dto.getAdresse());
+        mandat.setComplement(dto.getComplement());
+        mandat.setCodePostal(dto.getCodePostal());
+        mandat.setVille(dto.getVille());
+        mandat.setFichierRef(dto.getFichierRef());
+    }
+}


### PR DESCRIPTION
## Summary
- allow creating a syndic and uploading its documents in a single multipart request
- expand Mandat with number, mandatory dates, type, provisional administrator flag, address fields and file reference tied to a Syndic
- add controller/service/repository to create, fetch and update a Syndic's Mandat
- enable uploading and retrieving Mandat document files with dedicated service and endpoints

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68beb182dd38832a93941dc08d2b107a