### PR TITLE
Add Carnet entity timestamps and CRUD APIs

### DIFF
--- a/src/main/java/com/app/copro/controller/CarnetController.java
+++ b/src/main/java/com/app/copro/controller/CarnetController.java
@@ -1,0 +1,51 @@
+package com.app.copro.controller;
+
+import com.app.copro.model.Carnet;
+import com.app.copro.service.CarnetService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/carnets")
+@CrossOrigin(origins = "*")
+public class CarnetController {
+
+    private final CarnetService carnetService;
+
+    public CarnetController(CarnetService carnetService) {
+        this.carnetService = carnetService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Carnet> createCarnet() {
+        Carnet carnet = carnetService.createCarnet();
+        return new ResponseEntity<>(carnet, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/by-makeplan/{idMakePlan}")
+    public ResponseEntity<List<Carnet>> getCarnetsByIdProjetMakePlan(@PathVariable Long idMakePlan) {
+        List<Carnet> carnets = carnetService.getCarnetsByIdProjetMakePlan(idMakePlan);
+        return ResponseEntity.ok(carnets);
+    }
+
+    @GetMapping("/active")
+    public ResponseEntity<Carnet> getCarnetForActiveSyndic() {
+        Carnet carnet = carnetService.getCarnetForActiveSyndic();
+        return ResponseEntity.ok(carnet);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Carnet> updateCarnet(@PathVariable Long id, @RequestBody Carnet updatedCarnet) {
+        Carnet carnet = carnetService.updateCarnet(id, updatedCarnet);
+        return ResponseEntity.ok(carnet);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCarnet(@PathVariable Long id) {
+        carnetService.deleteCarnet(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/app/copro/model/Carnet.java
+++ b/src/main/java/com/app/copro/model/Carnet.java
@@ -3,6 +3,7 @@ package com.app.copro.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,11 +12,14 @@ public class Carnet {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 150)
-    private String titre;
+    @Version
+    private Long version;
 
-    @Column(length = 5000)
-    private String contenu;
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
 
     // ManyToOne vers Syndic (existant)
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -39,6 +43,17 @@ public class Carnet {
     @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TravailImportant> travauxImportants = new ArrayList<>();
 
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
     public Long getId() {
         return id;
     }
@@ -47,20 +62,28 @@ public class Carnet {
         this.id = id;
     }
 
-    public String getTitre() {
-        return titre;
+    public Long getVersion() {
+        return version;
     }
 
-    public void setTitre(String titre) {
-        this.titre = titre;
+    public void setVersion(Long version) {
+        this.version = version;
     }
 
-    public String getContenu() {
-        return contenu;
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
     }
 
-    public void setContenu(String contenu) {
-        this.contenu = contenu;
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
     }
 
     public Syndic getSyndic() {

--- a/src/main/java/com/app/copro/repository/CarnetRepository.java
+++ b/src/main/java/com/app/copro/repository/CarnetRepository.java
@@ -1,0 +1,14 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.Carnet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CarnetRepository extends JpaRepository<Carnet, Long> {
+    List<Carnet> findBySyndic_Projet_IdMakePlan(Long idMakePlan);
+    Optional<Carnet> findBySyndic_IsActiveTrue();
+}

--- a/src/main/java/com/app/copro/repository/SyndicRepository.java
+++ b/src/main/java/com/app/copro/repository/SyndicRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SyndicRepository extends JpaRepository<Syndic, Long> {
@@ -21,4 +22,6 @@ public interface SyndicRepository extends JpaRepository<Syndic, Long> {
 
     @Query("SELECT s FROM Syndic s JOIN FETCH s.projet p WHERE p.idMakePlan = :idMakePlan AND s.isActive = true")
     List<Syndic> findActiveSyndicsByProjetIdMakePlan(@Param("idMakePlan") Long idMakePlan);
+
+    Optional<Syndic> findByIsActiveTrue();
 }

--- a/src/main/java/com/app/copro/service/CarnetService.java
+++ b/src/main/java/com/app/copro/service/CarnetService.java
@@ -1,0 +1,52 @@
+package com.app.copro.service;
+
+import com.app.copro.model.Carnet;
+import com.app.copro.model.Syndic;
+import com.app.copro.repository.CarnetRepository;
+import com.app.copro.repository.SyndicRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CarnetService {
+
+    private final CarnetRepository carnetRepository;
+    private final SyndicRepository syndicRepository;
+
+    public CarnetService(CarnetRepository carnetRepository, SyndicRepository syndicRepository) {
+        this.carnetRepository = carnetRepository;
+        this.syndicRepository = syndicRepository;
+    }
+
+    public Carnet createCarnet() {
+        Syndic activeSyndic = syndicRepository.findByIsActiveTrue()
+                .orElseThrow(() -> new RuntimeException("Aucun syndic actif trouvé"));
+        Carnet carnet = new Carnet();
+        carnet.setSyndic(activeSyndic);
+        return carnetRepository.save(carnet);
+    }
+
+    public List<Carnet> getCarnetsByIdProjetMakePlan(Long idMakePlan) {
+        return carnetRepository.findBySyndic_Projet_IdMakePlan(idMakePlan);
+    }
+
+    public Carnet getCarnetForActiveSyndic() {
+        return carnetRepository.findBySyndic_IsActiveTrue()
+                .orElseThrow(() -> new RuntimeException("Aucun carnet pour le syndic actif"));
+    }
+
+    public Carnet updateCarnet(Long id, Carnet updatedCarnet) {
+        Carnet existing = carnetRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Carnet non trouvé"));
+        // For now, only syndic reassignment is allowed if provided
+        if (updatedCarnet.getSyndic() != null) {
+            existing.setSyndic(updatedCarnet.getSyndic());
+        }
+        return carnetRepository.save(existing);
+    }
+
+    public void deleteCarnet(Long id) {
+        carnetRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `Carnet` to include versioning and timestamps
- expose CRUD endpoints for `Carnet` bound to active `Syndic`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68c00f860674832ab650d714c724c3a3