### PR TITLE
feat: manage administrative data for carnets

### DIFF
--- a/src/main/java/com/app/copro/controller/DonneesAdministrativesController.java
+++ b/src/main/java/com/app/copro/controller/DonneesAdministrativesController.java
@@ -1,0 +1,39 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.DonneesAdministrativesDto;
+import com.app.copro.service.DonneesAdministrativesService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/carnets/{carnetId}/donnees-administratives")
+@CrossOrigin(origins = "*")
+public class DonneesAdministrativesController {
+
+    private final DonneesAdministrativesService service;
+
+    public DonneesAdministrativesController(DonneesAdministrativesService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<DonneesAdministrativesDto> create(@PathVariable Long carnetId,
+                                                            @RequestBody DonneesAdministrativesDto dto) {
+        DonneesAdministrativesDto created = service.create(carnetId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<DonneesAdministrativesDto> get(@PathVariable Long carnetId) {
+        DonneesAdministrativesDto dto = service.getByCarnet(carnetId);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping
+    public ResponseEntity<DonneesAdministrativesDto> update(@PathVariable Long carnetId,
+                                                            @RequestBody DonneesAdministrativesDto dto) {
+        DonneesAdministrativesDto updated = service.update(carnetId, dto);
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/src/main/java/com/app/copro/dto/DonneesAdministrativesDto.java
+++ b/src/main/java/com/app/copro/dto/DonneesAdministrativesDto.java
@@ -1,13 +1,8 @@
-package com.app.copro.model;
+package com.app.copro.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
 import java.time.LocalDate;
 
-@Entity @Table(name = "donnees_administratives")
-public class DonneesAdministratives {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+public class DonneesAdministrativesDto {
     private Long id;
 
     // Adresse principale
@@ -42,12 +37,6 @@ public class DonneesAdministratives {
     private Integer nbASL;
     private Integer nbAFUL;
     private Integer nbUnionSyndical;
-
-    // propriétaire de la relation 1–1 (clé unique)
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "carnet_id", unique = true, nullable = false)
-    @JsonIgnore
-    private Carnet carnet;
 
     public Long getId() {
         return id;
@@ -255,13 +244,5 @@ public class DonneesAdministratives {
 
     public void setNbUnionSyndical(Integer nbUnionSyndical) {
         this.nbUnionSyndical = nbUnionSyndical;
-    }
-
-    public Carnet getCarnet() {
-        return carnet;
-    }
-
-    public void setCarnet(Carnet carnet) {
-        this.carnet = carnet;
     }
 }

--- a/src/main/java/com/app/copro/repository/DonneesAdministrativesRepository.java
+++ b/src/main/java/com/app/copro/repository/DonneesAdministrativesRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.DonneesAdministratives;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DonneesAdministrativesRepository extends JpaRepository<DonneesAdministratives, Long> {
+    Optional<DonneesAdministratives> findByCarnetId(Long carnetId);
+}

--- a/src/main/java/com/app/copro/service/DonneesAdministrativesService.java
+++ b/src/main/java/com/app/copro/service/DonneesAdministrativesService.java
@@ -1,0 +1,111 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.DonneesAdministrativesDto;
+import com.app.copro.model.Carnet;
+import com.app.copro.model.DonneesAdministratives;
+import com.app.copro.repository.CarnetRepository;
+import com.app.copro.repository.DonneesAdministrativesRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DonneesAdministrativesService {
+
+    private final DonneesAdministrativesRepository repository;
+    private final CarnetRepository carnetRepository;
+
+    public DonneesAdministrativesService(DonneesAdministrativesRepository repository, CarnetRepository carnetRepository) {
+        this.repository = repository;
+        this.carnetRepository = carnetRepository;
+    }
+
+    @Transactional
+    public DonneesAdministrativesDto create(Long carnetId, DonneesAdministrativesDto dto) {
+        Carnet carnet = carnetRepository.findById(carnetId)
+                .orElseThrow(() -> new RuntimeException("Carnet not found"));
+
+        if (repository.findByCarnetId(carnetId).isPresent()) {
+            throw new IllegalStateException("Administrative data already exists for this carnet");
+        }
+
+        DonneesAdministratives entity = new DonneesAdministratives();
+        applyDtoToEntity(dto, entity);
+        entity.setCarnet(carnet);
+        DonneesAdministratives saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public DonneesAdministrativesDto getByCarnet(Long carnetId) {
+        DonneesAdministratives entity = repository.findByCarnetId(carnetId)
+                .orElseThrow(() -> new RuntimeException("Administrative data not found for carnet " + carnetId));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public DonneesAdministrativesDto update(Long carnetId, DonneesAdministrativesDto dto) {
+        DonneesAdministratives entity = repository.findByCarnetId(carnetId)
+                .orElseThrow(() -> new RuntimeException("Administrative data not found for carnet " + carnetId));
+        applyDtoToEntity(dto, entity);
+        DonneesAdministratives saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    private DonneesAdministrativesDto mapToDto(DonneesAdministratives entity) {
+        DonneesAdministrativesDto dto = new DonneesAdministrativesDto();
+        dto.setId(entity.getId());
+        dto.setAdressePrincipaleNumeroRue(entity.getAdressePrincipaleNumeroRue());
+        dto.setAdressePrincipaleComplement(entity.getAdressePrincipaleComplement());
+        dto.setAdressePrincipaleCodePostal(entity.getAdressePrincipaleCodePostal());
+        dto.setAdressePrincipaleVille(entity.getAdressePrincipaleVille());
+        dto.setAdressePrincipalePays(entity.getAdressePrincipalePays());
+        dto.setAdresseSecondaireNumeroRue(entity.getAdresseSecondaireNumeroRue());
+        dto.setAdresseSecondaireComplement(entity.getAdresseSecondaireComplement());
+        dto.setAdresseSecondaireCodePostal(entity.getAdresseSecondaireCodePostal());
+        dto.setAdresseSecondaireVille(entity.getAdresseSecondaireVille());
+        dto.setAdresseSecondairePays(entity.getAdresseSecondairePays());
+        dto.setAutreAdresseSecondaireNumeroRue(entity.getAutreAdresseSecondaireNumeroRue());
+        dto.setAutreAdresseSecondaireComplement(entity.getAutreAdresseSecondaireComplement());
+        dto.setAutreAdresseSecondaireCodePostal(entity.getAutreAdresseSecondaireCodePostal());
+        dto.setAutreAdresseSecondaireVille(entity.getAutreAdresseSecondaireVille());
+        dto.setAutreAdresseSecondairePays(entity.getAutreAdresseSecondairePays());
+        dto.setDateReglementCopropriete(entity.getDateReglementCopropriete());
+        dto.setDateDerniereModificationReglementCopropriete(entity.getDateDerniereModificationReglementCopropriete());
+        dto.setResidenceService(entity.getResidenceService());
+        dto.setSiret(entity.getSiret());
+        dto.setSyndicatCooperatif(entity.getSyndicatCooperatif());
+        dto.setSyndicatPrincipal(entity.getSyndicatPrincipal());
+        dto.setNumeroImmatriculationCoproprietePrincipale(entity.getNumeroImmatriculationCoproprietePrincipale());
+        dto.setNbASL(entity.getNbASL());
+        dto.setNbAFUL(entity.getNbAFUL());
+        dto.setNbUnionSyndical(entity.getNbUnionSyndical());
+        return dto;
+    }
+
+    private void applyDtoToEntity(DonneesAdministrativesDto dto, DonneesAdministratives entity) {
+        entity.setAdressePrincipaleNumeroRue(dto.getAdressePrincipaleNumeroRue());
+        entity.setAdressePrincipaleComplement(dto.getAdressePrincipaleComplement());
+        entity.setAdressePrincipaleCodePostal(dto.getAdressePrincipaleCodePostal());
+        entity.setAdressePrincipaleVille(dto.getAdressePrincipaleVille());
+        entity.setAdressePrincipalePays(dto.getAdressePrincipalePays());
+        entity.setAdresseSecondaireNumeroRue(dto.getAdresseSecondaireNumeroRue());
+        entity.setAdresseSecondaireComplement(dto.getAdresseSecondaireComplement());
+        entity.setAdresseSecondaireCodePostal(dto.getAdresseSecondaireCodePostal());
+        entity.setAdresseSecondaireVille(dto.getAdresseSecondaireVille());
+        entity.setAdresseSecondairePays(dto.getAdresseSecondairePays());
+        entity.setAutreAdresseSecondaireNumeroRue(dto.getAutreAdresseSecondaireNumeroRue());
+        entity.setAutreAdresseSecondaireComplement(dto.getAutreAdresseSecondaireComplement());
+        entity.setAutreAdresseSecondaireCodePostal(dto.getAutreAdresseSecondaireCodePostal());
+        entity.setAutreAdresseSecondaireVille(dto.getAutreAdresseSecondaireVille());
+        entity.setAutreAdresseSecondairePays(dto.getAutreAdresseSecondairePays());
+        entity.setDateReglementCopropriete(dto.getDateReglementCopropriete());
+        entity.setDateDerniereModificationReglementCopropriete(dto.getDateDerniereModificationReglementCopropriete());
+        entity.setResidenceService(dto.getResidenceService());
+        entity.setSiret(dto.getSiret());
+        entity.setSyndicatCooperatif(dto.getSyndicatCooperatif());
+        entity.setSyndicatPrincipal(dto.getSyndicatPrincipal());
+        entity.setNumeroImmatriculationCoproprietePrincipale(dto.getNumeroImmatriculationCoproprietePrincipale());
+        entity.setNbASL(dto.getNbASL());
+        entity.setNbAFUL(dto.getNbAFUL());
+        entity.setNbUnionSyndical(dto.getNbUnionSyndical());
+    }
+}


### PR DESCRIPTION
## Summary
- expose CRUD endpoints for administrative data tied to a carnet
- wire repository and service layers with DTO mapping
- add accessors for administrative data entity fields

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c14c887f3c832a8ab7a9dae670044a