### PR TITLE
feat: expose insurance contract APIs

### DIFF
--- a/src/main/java/com/app/copro/controller/ContratAssuranceController.java
+++ b/src/main/java/com/app/copro/controller/ContratAssuranceController.java
@@ -1,0 +1,84 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.ContratAssuranceDto;
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.service.ContratAssuranceFileService;
+import com.app.copro.service.ContratAssuranceService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class ContratAssuranceController {
+
+    private final ContratAssuranceService service;
+    private final ContratAssuranceFileService fileService;
+
+    public ContratAssuranceController(ContratAssuranceService service, ContratAssuranceFileService fileService) {
+        this.service = service;
+        this.fileService = fileService;
+    }
+
+    @PostMapping("/carnets/{carnetId}/contrats-assurance")
+    public ResponseEntity<ContratAssuranceDto> create(@PathVariable Long carnetId,
+                                                       @Valid @RequestBody ContratAssuranceDto dto) {
+        ContratAssuranceDto created = service.create(carnetId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/carnets/{carnetId}/contrats-assurance/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ContratAssuranceDto> createWithFile(@PathVariable Long carnetId,
+                                                              @RequestPart("contrat") @Valid ContratAssuranceDto dto,
+                                                              @RequestPart(value = "file", required = false) MultipartFile file) {
+        ContratAssuranceDto created = service.create(carnetId, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), file);
+            created.setFichierRef(ref);
+        }
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/carnets/{carnetId}/contrats-assurance")
+    public ResponseEntity<List<ContratAssuranceDto>> getByCarnet(@PathVariable Long carnetId) {
+        List<ContratAssuranceDto> list = service.getByCarnet(carnetId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/contrats-assurance/{id}")
+    public ResponseEntity<ContratAssuranceDto> getById(@PathVariable Long id) {
+        ContratAssuranceDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/contrats-assurance/{id}")
+    public ResponseEntity<ContratAssuranceDto> update(@PathVariable Long id,
+                                                      @Valid @RequestBody ContratAssuranceDto dto) {
+        ContratAssuranceDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/contrats-assurance/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/contrats-assurance/{id}/file")
+    public ResponseEntity<String> uploadFile(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+        String ref = fileService.uploadFile(id, file);
+        return ref != null ? ResponseEntity.ok(ref) : ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/contrats-assurance/{id}/file")
+    public ResponseEntity<FileResponseDto> getFile(@PathVariable Long id) {
+        FileResponseDto file = fileService.getFile(id);
+        return file != null ? ResponseEntity.ok(file) : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/app/copro/dto/ContratAssuranceDto.java
+++ b/src/main/java/com/app/copro/dto/ContratAssuranceDto.java
@@ -1,74 +1,26 @@
-package com.app.copro.model;
+package com.app.copro.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
-
+import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDate;
 
-@Entity
-@Table(name = "contrat_assurance")
-public class ContratAssurance {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+public class ContratAssuranceDto {
     private Long id;
 
-    /**
-     * Type de contrat (ex. Multirisque)
-     */
-    @Column(nullable = false)
+    @NotBlank
     private String contrat;
 
-    /**
-     * Assureur sélectionné
-     */
-    @Column(nullable = false)
+    @NotBlank
     private String assureur;
 
-    /**
-     * Compagnie d'assurance (ex. Otis)
-     */
-    @Column(nullable = false)
+    @NotBlank
     private String compagnie;
 
-    /**
-     * Numéro de contrat
-     */
     private String numeroContrat;
-
-    /**
-     * Numéro de police
-     */
     private String numeroPolice;
-
-    /**
-     * Date d'effet du contrat
-     */
     private LocalDate dateEffet;
-
-    /**
-     * Date de fin du contrat
-     */
     private LocalDate dateFin;
-
-    /**
-     * Prime d'assurance
-     */
     private Double prime;
-
-    /**
-     * Référence vers le fichier associé (upload)
-     */
-    @Column(length = 255)
     private String fichierRef;
-
-    // Relation N–1 vers Carnet (côté propriétaire)
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "carnet_id")
-    @JsonIgnore
-    private Carnet carnet;
-
-    // ===== Getters/Setters =====
 
     public Long getId() {
         return id;
@@ -148,14 +100,6 @@ public class ContratAssurance {
 
     public void setFichierRef(String fichierRef) {
         this.fichierRef = fichierRef;
-    }
-
-    public Carnet getCarnet() {
-        return carnet;
-    }
-
-    public void setCarnet(Carnet carnet) {
-        this.carnet = carnet;
     }
 }
 

--- a/src/main/java/com/app/copro/exception/ContratAssuranceNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/ContratAssuranceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.app.copro.exception;
+
+public class ContratAssuranceNotFoundException extends RuntimeException {
+    public ContratAssuranceNotFoundException(Long id) {
+        super("Contrat d'assurance not found with id " + id);
+    }
+}

--- a/src/main/java/com/app/copro/repository/ContratAssuranceRepository.java
+++ b/src/main/java/com/app/copro/repository/ContratAssuranceRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.ContratAssurance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ContratAssuranceRepository extends JpaRepository<ContratAssurance, Long> {
+    List<ContratAssurance> findByCarnetId(Long carnetId);
+}

--- a/src/main/java/com/app/copro/service/ContratAssuranceFileService.java
+++ b/src/main/java/com/app/copro/service/ContratAssuranceFileService.java
@@ -1,0 +1,48 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.exception.ContratAssuranceNotFoundException;
+import com.app.copro.model.ContratAssurance;
+import com.app.copro.repository.ContratAssuranceRepository;
+import com.app.copro.util.FileConstants;
+import com.app.copro.util.FileManagerHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+public class ContratAssuranceFileService {
+
+    @Autowired
+    private FileManagerHelper fileManagerHelper;
+
+    @Autowired
+    private ContratAssuranceRepository repository;
+
+    public String uploadFile(Long contratId, MultipartFile file) {
+        ContratAssurance contrat = repository.findById(contratId)
+                .orElseThrow(() -> new ContratAssuranceNotFoundException(contratId));
+
+        String fileRef = fileManagerHelper.uploadEntityDocument(
+                file,
+                FileConstants.EntityTypes.CONTRAT_ASSURANCE,
+                contrat.getId(),
+                FileConstants.CommonCategories.CONTRAT,
+                "Document contrat assurance"
+        );
+
+        if (fileRef != null) {
+            contrat.setFichierRef(fileRef);
+            repository.save(contrat);
+        }
+
+        return fileRef;
+    }
+
+    public FileResponseDto getFile(Long contratId) {
+        Optional<ContratAssurance> contratOpt = repository.findById(contratId);
+        return contratOpt.map(c -> fileManagerHelper.parseFileReference(c.getFichierRef())).orElse(null);
+    }
+}

--- a/src/main/java/com/app/copro/service/ContratAssuranceService.java
+++ b/src/main/java/com/app/copro/service/ContratAssuranceService.java
@@ -1,0 +1,92 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.ContratAssuranceDto;
+import com.app.copro.exception.ContratAssuranceNotFoundException;
+import com.app.copro.model.Carnet;
+import com.app.copro.model.ContratAssurance;
+import com.app.copro.repository.CarnetRepository;
+import com.app.copro.repository.ContratAssuranceRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ContratAssuranceService {
+
+    private final ContratAssuranceRepository repository;
+    private final CarnetRepository carnetRepository;
+
+    public ContratAssuranceService(ContratAssuranceRepository repository, CarnetRepository carnetRepository) {
+        this.repository = repository;
+        this.carnetRepository = carnetRepository;
+    }
+
+    @Transactional
+    public ContratAssuranceDto create(Long carnetId, ContratAssuranceDto dto) {
+        Carnet carnet = carnetRepository.findById(carnetId)
+                .orElseThrow(() -> new RuntimeException("Carnet not found"));
+        ContratAssurance entity = new ContratAssurance();
+        applyDtoToEntity(dto, entity);
+        entity.setCarnet(carnet);
+        ContratAssurance saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<ContratAssuranceDto> getByCarnet(Long carnetId) {
+        return repository.findByCarnetId(carnetId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public ContratAssuranceDto getById(Long id) {
+        ContratAssurance entity = repository.findById(id)
+                .orElseThrow(() -> new ContratAssuranceNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public ContratAssuranceDto update(Long id, ContratAssuranceDto dto) {
+        ContratAssurance entity = repository.findById(id)
+                .orElseThrow(() -> new ContratAssuranceNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        ContratAssurance saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new ContratAssuranceNotFoundException(id);
+        }
+        repository.deleteById(id);
+    }
+
+    private ContratAssuranceDto mapToDto(ContratAssurance entity) {
+        ContratAssuranceDto dto = new ContratAssuranceDto();
+        dto.setId(entity.getId());
+        dto.setContrat(entity.getContrat());
+        dto.setAssureur(entity.getAssureur());
+        dto.setCompagnie(entity.getCompagnie());
+        dto.setNumeroContrat(entity.getNumeroContrat());
+        dto.setNumeroPolice(entity.getNumeroPolice());
+        dto.setDateEffet(entity.getDateEffet());
+        dto.setDateFin(entity.getDateFin());
+        dto.setPrime(entity.getPrime());
+        dto.setFichierRef(entity.getFichierRef());
+        return dto;
+    }
+
+    private void applyDtoToEntity(ContratAssuranceDto dto, ContratAssurance entity) {
+        entity.setContrat(dto.getContrat());
+        entity.setAssureur(dto.getAssureur());
+        entity.setCompagnie(dto.getCompagnie());
+        entity.setNumeroContrat(dto.getNumeroContrat());
+        entity.setNumeroPolice(dto.getNumeroPolice());
+        entity.setDateEffet(dto.getDateEffet());
+        entity.setDateFin(dto.getDateFin());
+        entity.setPrime(dto.getPrime());
+        entity.setFichierRef(dto.getFichierRef());
+    }
+}

--- a/src/main/java/com/app/copro/util/FileConstants.java
+++ b/src/main/java/com/app/copro/util/FileConstants.java
@@ -10,6 +10,7 @@ public final class FileConstants {
         public static final String MANDAT = "MANDAT";
         public static final String CARNET = "CARNET";
         public static final String PROJET = "PROJET";
+        public static final String CONTRAT_ASSURANCE = "CONTRAT_ASSURANCE";
     }
 
     public static final class SyndicCategories {


### PR DESCRIPTION
## Summary
- expand `ContratAssurance` with insurer, company, contract numbers, dates, premium and file reference
- represent insurance premium as `Double` instead of `BigDecimal`
- add REST endpoints and service layer to manage insurance contracts per carnet, including file upload and retrieval
- register contract entity type for file storage

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c18440adc8832a808ce4531d0aab6d