### PR TITLE
Add diagnostics collectifs entity with file uploads

### DIFF
--- a/src/main/java/com/app/copro/controller/DiagnosticCollectifController.java
+++ b/src/main/java/com/app/copro/controller/DiagnosticCollectifController.java
@@ -1,0 +1,98 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.DiagnosticCollectifDto;
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.service.DiagnosticCollectifFileService;
+import com.app.copro.service.DiagnosticCollectifService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class DiagnosticCollectifController {
+
+    private final DiagnosticCollectifService service;
+    private final DiagnosticCollectifFileService fileService;
+
+    public DiagnosticCollectifController(DiagnosticCollectifService service,
+                                         DiagnosticCollectifFileService fileService) {
+        this.service = service;
+        this.fileService = fileService;
+    }
+
+    @PostMapping("/carnets/{carnetId}/diagnostics-collectifs")
+    public ResponseEntity<DiagnosticCollectifDto> create(@PathVariable Long carnetId,
+                                                          @Valid @RequestBody DiagnosticCollectifDto dto) {
+        DiagnosticCollectifDto created = service.create(carnetId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/carnets/{carnetId}/diagnostics-collectifs/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<DiagnosticCollectifDto> createWithFile(@PathVariable Long carnetId,
+                                                                 @RequestPart("diagnostic") @Valid DiagnosticCollectifDto dto,
+                                                                 @RequestPart(value = "file", required = false) MultipartFile file) {
+        DiagnosticCollectifDto created = service.create(carnetId, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), file);
+            created.setFichierRef(ref);
+        }
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/carnets/{carnetId}/diagnostics-collectifs")
+    public ResponseEntity<List<DiagnosticCollectifDto>> getByCarnet(@PathVariable Long carnetId) {
+        List<DiagnosticCollectifDto> list = service.getByCarnet(carnetId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/diagnostics-collectifs/{id}")
+    public ResponseEntity<DiagnosticCollectifDto> getById(@PathVariable Long id) {
+        DiagnosticCollectifDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/diagnostics-collectifs/{id}")
+    public ResponseEntity<DiagnosticCollectifDto> update(@PathVariable Long id,
+                                                          @Valid @RequestBody DiagnosticCollectifDto dto) {
+        DiagnosticCollectifDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @PutMapping(value = "/diagnostics-collectifs/{id}/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<DiagnosticCollectifDto> updateWithFile(@PathVariable Long id,
+                                                                 @RequestPart("diagnostic") @Valid DiagnosticCollectifDto dto,
+                                                                 @RequestPart(value = "file", required = false) MultipartFile file) {
+        DiagnosticCollectifDto updated = service.update(id, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(updated.getId(), file);
+            updated.setFichierRef(ref);
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/diagnostics-collectifs/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/diagnostics-collectifs/{id}/file")
+    public ResponseEntity<String> uploadFile(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+        String ref = fileService.uploadFile(id, file);
+        return ref != null ? ResponseEntity.ok(ref) : ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/diagnostics-collectifs/{id}/file")
+    public ResponseEntity<FileResponseDto> getFile(@PathVariable Long id) {
+        FileResponseDto file = fileService.getFile(id);
+        return file != null ? ResponseEntity.ok(file) : ResponseEntity.notFound().build();
+    }
+}
+

--- a/src/main/java/com/app/copro/dto/DiagnosticCollectifDto.java
+++ b/src/main/java/com/app/copro/dto/DiagnosticCollectifDto.java
@@ -1,0 +1,122 @@
+package com.app.copro.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public class DiagnosticCollectifDto {
+    private Long id;
+
+    @NotBlank
+    private String diagnostiqueur;
+
+    @NotBlank
+    private String typeDiagnostic;
+
+    @NotBlank
+    private String refPv;
+
+    private Double montant;
+
+    @NotNull
+    private LocalDate dateControle;
+
+    private LocalDate dateEcheance;
+
+    private String valeur;
+
+    private String indicateur;
+
+    private String description;
+
+    private String fichierRef;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDiagnostiqueur() {
+        return diagnostiqueur;
+    }
+
+    public void setDiagnostiqueur(String diagnostiqueur) {
+        this.diagnostiqueur = diagnostiqueur;
+    }
+
+    public String getTypeDiagnostic() {
+        return typeDiagnostic;
+    }
+
+    public void setTypeDiagnostic(String typeDiagnostic) {
+        this.typeDiagnostic = typeDiagnostic;
+    }
+
+    public String getRefPv() {
+        return refPv;
+    }
+
+    public void setRefPv(String refPv) {
+        this.refPv = refPv;
+    }
+
+    public Double getMontant() {
+        return montant;
+    }
+
+    public void setMontant(Double montant) {
+        this.montant = montant;
+    }
+
+    public LocalDate getDateControle() {
+        return dateControle;
+    }
+
+    public void setDateControle(LocalDate dateControle) {
+        this.dateControle = dateControle;
+    }
+
+    public LocalDate getDateEcheance() {
+        return dateEcheance;
+    }
+
+    public void setDateEcheance(LocalDate dateEcheance) {
+        this.dateEcheance = dateEcheance;
+    }
+
+    public String getValeur() {
+        return valeur;
+    }
+
+    public void setValeur(String valeur) {
+        this.valeur = valeur;
+    }
+
+    public String getIndicateur() {
+        return indicateur;
+    }
+
+    public void setIndicateur(String indicateur) {
+        this.indicateur = indicateur;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getFichierRef() {
+        return fichierRef;
+    }
+
+    public void setFichierRef(String fichierRef) {
+        this.fichierRef = fichierRef;
+    }
+}
+

--- a/src/main/java/com/app/copro/exception/DiagnosticCollectifNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/DiagnosticCollectifNotFoundException.java
@@ -1,0 +1,8 @@
+package com.app.copro.exception;
+
+public class DiagnosticCollectifNotFoundException extends RuntimeException {
+    public DiagnosticCollectifNotFoundException(Long id) {
+        super("Diagnostic collectif not found with id " + id);
+    }
+}
+

--- a/src/main/java/com/app/copro/model/Carnet.java
+++ b/src/main/java/com/app/copro/model/Carnet.java
@@ -43,6 +43,10 @@ public class Carnet {
     @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TravailImportant> travauxImportants = new ArrayList<>();
 
+    // 1–N Diagnostics collectifs (FK côté DiagnosticCollectif)
+    @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiagnosticCollectif> diagnosticsCollectifs = new ArrayList<>();
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
@@ -124,5 +128,13 @@ public class Carnet {
 
     public void setTravauxImportants(List<TravailImportant> travauxImportants) {
         this.travauxImportants = travauxImportants;
+    }
+
+    public List<DiagnosticCollectif> getDiagnosticsCollectifs() {
+        return diagnosticsCollectifs;
+    }
+
+    public void setDiagnosticsCollectifs(List<DiagnosticCollectif> diagnosticsCollectifs) {
+        this.diagnosticsCollectifs = diagnosticsCollectifs;
     }
 }

--- a/src/main/java/com/app/copro/model/DiagnosticCollectif.java
+++ b/src/main/java/com/app/copro/model/DiagnosticCollectif.java
@@ -1,0 +1,143 @@
+package com.app.copro.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "diagnostic_collectif")
+public class DiagnosticCollectif {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String diagnostiqueur;
+
+    @Column(name = "type_diagnostic", nullable = false)
+    private String typeDiagnostic;
+
+    @Column(name = "ref_pv", nullable = false)
+    private String refPv;
+
+    private Double montant;
+
+    @Column(name = "date_controle", nullable = false)
+    private LocalDate dateControle;
+
+    @Column(name = "date_echeance")
+    private LocalDate dateEcheance;
+
+    private String valeur;
+
+    private String indicateur;
+
+    @Column(length = 1000)
+    private String description;
+
+    @Column(length = 255)
+    private String fichierRef;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "carnet_id")
+    @JsonIgnore
+    private Carnet carnet;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDiagnostiqueur() {
+        return diagnostiqueur;
+    }
+
+    public void setDiagnostiqueur(String diagnostiqueur) {
+        this.diagnostiqueur = diagnostiqueur;
+    }
+
+    public String getTypeDiagnostic() {
+        return typeDiagnostic;
+    }
+
+    public void setTypeDiagnostic(String typeDiagnostic) {
+        this.typeDiagnostic = typeDiagnostic;
+    }
+
+    public String getRefPv() {
+        return refPv;
+    }
+
+    public void setRefPv(String refPv) {
+        this.refPv = refPv;
+    }
+
+    public Double getMontant() {
+        return montant;
+    }
+
+    public void setMontant(Double montant) {
+        this.montant = montant;
+    }
+
+    public LocalDate getDateControle() {
+        return dateControle;
+    }
+
+    public void setDateControle(LocalDate dateControle) {
+        this.dateControle = dateControle;
+    }
+
+    public LocalDate getDateEcheance() {
+        return dateEcheance;
+    }
+
+    public void setDateEcheance(LocalDate dateEcheance) {
+        this.dateEcheance = dateEcheance;
+    }
+
+    public String getValeur() {
+        return valeur;
+    }
+
+    public void setValeur(String valeur) {
+        this.valeur = valeur;
+    }
+
+    public String getIndicateur() {
+        return indicateur;
+    }
+
+    public void setIndicateur(String indicateur) {
+        this.indicateur = indicateur;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getFichierRef() {
+        return fichierRef;
+    }
+
+    public void setFichierRef(String fichierRef) {
+        this.fichierRef = fichierRef;
+    }
+
+    public Carnet getCarnet() {
+        return carnet;
+    }
+
+    public void setCarnet(Carnet carnet) {
+        this.carnet = carnet;
+    }
+}
+

--- a/src/main/java/com/app/copro/repository/DiagnosticCollectifRepository.java
+++ b/src/main/java/com/app/copro/repository/DiagnosticCollectifRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.DiagnosticCollectif;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface DiagnosticCollectifRepository extends JpaRepository<DiagnosticCollectif, Long> {
+    List<DiagnosticCollectif> findByCarnetId(Long carnetId);
+}
+

--- a/src/main/java/com/app/copro/service/DiagnosticCollectifFileService.java
+++ b/src/main/java/com/app/copro/service/DiagnosticCollectifFileService.java
@@ -1,0 +1,49 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.exception.DiagnosticCollectifNotFoundException;
+import com.app.copro.model.DiagnosticCollectif;
+import com.app.copro.repository.DiagnosticCollectifRepository;
+import com.app.copro.util.FileConstants;
+import com.app.copro.util.FileManagerHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+public class DiagnosticCollectifFileService {
+
+    @Autowired
+    private FileManagerHelper fileManagerHelper;
+
+    @Autowired
+    private DiagnosticCollectifRepository repository;
+
+    public String uploadFile(Long diagnosticId, MultipartFile file) {
+        DiagnosticCollectif diagnostic = repository.findById(diagnosticId)
+                .orElseThrow(() -> new DiagnosticCollectifNotFoundException(diagnosticId));
+
+        String fileRef = fileManagerHelper.uploadEntityDocument(
+                file,
+                FileConstants.EntityTypes.DIAGNOSTIC_COLLECTIF,
+                diagnostic.getId(),
+                FileConstants.CommonCategories.RAPPORT,
+                "Rapport diagnostic collectif"
+        );
+
+        if (fileRef != null) {
+            diagnostic.setFichierRef(fileRef);
+            repository.save(diagnostic);
+        }
+
+        return fileRef;
+    }
+
+    public FileResponseDto getFile(Long diagnosticId) {
+        Optional<DiagnosticCollectif> opt = repository.findById(diagnosticId);
+        return opt.map(d -> fileManagerHelper.parseFileReference(d.getFichierRef())).orElse(null);
+    }
+}
+

--- a/src/main/java/com/app/copro/service/DiagnosticCollectifService.java
+++ b/src/main/java/com/app/copro/service/DiagnosticCollectifService.java
@@ -1,0 +1,95 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.DiagnosticCollectifDto;
+import com.app.copro.exception.DiagnosticCollectifNotFoundException;
+import com.app.copro.model.Carnet;
+import com.app.copro.model.DiagnosticCollectif;
+import com.app.copro.repository.CarnetRepository;
+import com.app.copro.repository.DiagnosticCollectifRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class DiagnosticCollectifService {
+
+    private final DiagnosticCollectifRepository repository;
+    private final CarnetRepository carnetRepository;
+
+    public DiagnosticCollectifService(DiagnosticCollectifRepository repository, CarnetRepository carnetRepository) {
+        this.repository = repository;
+        this.carnetRepository = carnetRepository;
+    }
+
+    @Transactional
+    public DiagnosticCollectifDto create(Long carnetId, DiagnosticCollectifDto dto) {
+        Carnet carnet = carnetRepository.findById(carnetId)
+                .orElseThrow(() -> new RuntimeException("Carnet not found"));
+        DiagnosticCollectif entity = new DiagnosticCollectif();
+        applyDtoToEntity(dto, entity);
+        entity.setCarnet(carnet);
+        DiagnosticCollectif saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<DiagnosticCollectifDto> getByCarnet(Long carnetId) {
+        return repository.findByCarnetId(carnetId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public DiagnosticCollectifDto getById(Long id) {
+        DiagnosticCollectif entity = repository.findById(id)
+                .orElseThrow(() -> new DiagnosticCollectifNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public DiagnosticCollectifDto update(Long id, DiagnosticCollectifDto dto) {
+        DiagnosticCollectif entity = repository.findById(id)
+                .orElseThrow(() -> new DiagnosticCollectifNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        DiagnosticCollectif saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new DiagnosticCollectifNotFoundException(id);
+        }
+        repository.deleteById(id);
+    }
+
+    private DiagnosticCollectifDto mapToDto(DiagnosticCollectif entity) {
+        DiagnosticCollectifDto dto = new DiagnosticCollectifDto();
+        dto.setId(entity.getId());
+        dto.setDiagnostiqueur(entity.getDiagnostiqueur());
+        dto.setTypeDiagnostic(entity.getTypeDiagnostic());
+        dto.setRefPv(entity.getRefPv());
+        dto.setMontant(entity.getMontant());
+        dto.setDateControle(entity.getDateControle());
+        dto.setDateEcheance(entity.getDateEcheance());
+        dto.setValeur(entity.getValeur());
+        dto.setIndicateur(entity.getIndicateur());
+        dto.setDescription(entity.getDescription());
+        dto.setFichierRef(entity.getFichierRef());
+        return dto;
+    }
+
+    private void applyDtoToEntity(DiagnosticCollectifDto dto, DiagnosticCollectif entity) {
+        entity.setDiagnostiqueur(dto.getDiagnostiqueur());
+        entity.setTypeDiagnostic(dto.getTypeDiagnostic());
+        entity.setRefPv(dto.getRefPv());
+        entity.setMontant(dto.getMontant());
+        entity.setDateControle(dto.getDateControle());
+        entity.setDateEcheance(dto.getDateEcheance());
+        entity.setValeur(dto.getValeur());
+        entity.setIndicateur(dto.getIndicateur());
+        entity.setDescription(dto.getDescription());
+        entity.setFichierRef(dto.getFichierRef());
+    }
+}
+

--- a/src/main/java/com/app/copro/util/FileConstants.java
+++ b/src/main/java/com/app/copro/util/FileConstants.java
@@ -11,6 +11,7 @@ public final class FileConstants {
         public static final String CARNET = "CARNET";
         public static final String PROJET = "PROJET";
         public static final String CONTRAT_ASSURANCE = "CONTRAT_ASSURANCE";
+        public static final String DIAGNOSTIC_COLLECTIF = "DIAGNOSTIC_COLLECTIF";
     }
 
     public static final class SyndicCategories {


### PR DESCRIPTION
## Summary
- add DiagnosticCollectif entity linked to carnets
- expose CRUD REST endpoints with optional file upload and retrieval
- integrate file management with S3 helper and constants

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a099a8b4832a94f2946e1f8a64d8