### PR TITLE
Add TravailImportant CRUD endpoints and file uploads

### DIFF
--- a/src/main/java/com/app/copro/controller/CarnetController.java
+++ b/src/main/java/com/app/copro/controller/CarnetController.java
@@ -19,9 +19,9 @@ public class CarnetController {
         this.carnetService = carnetService;
     }
 
-    @PostMapping
-    public ResponseEntity<Carnet> createCarnet() {
-        Carnet carnet = carnetService.createCarnet();
+    @PostMapping("/projet/{projetId}")
+    public ResponseEntity<Carnet> createCarnet(@PathVariable Long projetId) {
+        Carnet carnet = carnetService.createCarnet(projetId);
         return new ResponseEntity<>(carnet, HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/app/copro/controller/CarnetController.java
+++ b/src/main/java/com/app/copro/controller/CarnetController.java
@@ -19,9 +19,9 @@ public class CarnetController {
         this.carnetService = carnetService;
     }
 
-    @PostMapping("/projet/{projetId}")
-    public ResponseEntity<Carnet> createCarnet(@PathVariable Long projetId) {
-        Carnet carnet = carnetService.createCarnet(projetId);
+    @PostMapping("/projet/{idMakePlan}")
+    public ResponseEntity<Carnet> createCarnet(@PathVariable Long idMakePlan) {
+        Carnet carnet = carnetService.createCarnet(idMakePlan);
         return new ResponseEntity<>(carnet, HttpStatus.CREATED);
     }
 

--- a/src/main/java/com/app/copro/controller/TravailImportantController.java
+++ b/src/main/java/com/app/copro/controller/TravailImportantController.java
@@ -1,0 +1,120 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.dto.TravailImportantDto;
+import com.app.copro.service.TravailImportantFileService;
+import com.app.copro.service.TravailImportantService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class TravailImportantController {
+
+    private final TravailImportantService service;
+    private final TravailImportantFileService fileService;
+
+    public TravailImportantController(TravailImportantService service, TravailImportantFileService fileService) {
+        this.service = service;
+        this.fileService = fileService;
+    }
+
+    @PostMapping("/carnets/{carnetId}/travaux-importants")
+    public ResponseEntity<TravailImportantDto> create(@PathVariable Long carnetId,
+                                                       @Valid @RequestBody TravailImportantDto dto) {
+        TravailImportantDto created = service.create(carnetId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/carnets/{carnetId}/travaux-importants/with-files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<TravailImportantDto> createWithFiles(@PathVariable Long carnetId,
+                                                               @RequestPart("travail") @Valid TravailImportantDto dto,
+                                                               @RequestPart(value = "image1", required = false) MultipartFile image1,
+                                                               @RequestPart(value = "image2", required = false) MultipartFile image2,
+                                                               @RequestPart(value = "image3", required = false) MultipartFile image3) {
+        TravailImportantDto created = service.create(carnetId, dto);
+        if (image1 != null && !image1.isEmpty()) {
+            String ref = fileService.uploadImage(created.getId(), image1, 1);
+            created.setImage1Ref(ref);
+        }
+        if (image2 != null && !image2.isEmpty()) {
+            String ref = fileService.uploadImage(created.getId(), image2, 2);
+            created.setImage2Ref(ref);
+        }
+        if (image3 != null && !image3.isEmpty()) {
+            String ref = fileService.uploadImage(created.getId(), image3, 3);
+            created.setImage3Ref(ref);
+        }
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/carnets/{carnetId}/travaux-importants")
+    public ResponseEntity<List<TravailImportantDto>> getByCarnet(@PathVariable Long carnetId) {
+        List<TravailImportantDto> list = service.getByCarnet(carnetId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/travaux-importants/{id}")
+    public ResponseEntity<TravailImportantDto> getById(@PathVariable Long id) {
+        TravailImportantDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/travaux-importants/{id}")
+    public ResponseEntity<TravailImportantDto> update(@PathVariable Long id,
+                                                      @Valid @RequestBody TravailImportantDto dto) {
+        TravailImportantDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @PutMapping(value = "/travaux-importants/{id}/with-files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<TravailImportantDto> updateWithFiles(@PathVariable Long id,
+                                                               @RequestPart("travail") @Valid TravailImportantDto dto,
+                                                               @RequestPart(value = "image1", required = false) MultipartFile image1,
+                                                               @RequestPart(value = "image2", required = false) MultipartFile image2,
+                                                               @RequestPart(value = "image3", required = false) MultipartFile image3) {
+        TravailImportantDto updated = service.update(id, dto);
+        if (image1 != null && !image1.isEmpty()) {
+            String ref = fileService.uploadImage(updated.getId(), image1, 1);
+            updated.setImage1Ref(ref);
+        }
+        if (image2 != null && !image2.isEmpty()) {
+            String ref = fileService.uploadImage(updated.getId(), image2, 2);
+            updated.setImage2Ref(ref);
+        }
+        if (image3 != null && !image3.isEmpty()) {
+            String ref = fileService.uploadImage(updated.getId(), image3, 3);
+            updated.setImage3Ref(ref);
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/travaux-importants/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/travaux-importants/{id}/images/{index}")
+    public ResponseEntity<String> uploadImage(@PathVariable Long id,
+                                              @PathVariable int index,
+                                              @RequestParam("file") MultipartFile file) {
+        String ref = fileService.uploadImage(id, file, index);
+        return ref != null ? ResponseEntity.ok(ref) : ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/travaux-importants/{id}/images/{index}")
+    public ResponseEntity<FileResponseDto> getImage(@PathVariable Long id,
+                                                    @PathVariable int index) {
+        FileResponseDto file = fileService.getImage(id, index);
+        return file != null ? ResponseEntity.ok(file) : ResponseEntity.notFound().build();
+    }
+}
+

--- a/src/main/java/com/app/copro/dto/TravailImportantDto.java
+++ b/src/main/java/com/app/copro/dto/TravailImportantDto.java
@@ -1,64 +1,37 @@
-package com.app.copro.model;
+package com.app.copro.dto;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
 /**
- * Entité représentant un travail important réalisé dans la copropriété.
+ * DTO pour l'entité {@code TravailImportant}.
  */
-@Entity
-@Table(name = "travail_important")
-public class TravailImportant {
+public class TravailImportantDto {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /** Nom des travaux. */
-    @Column(nullable = false)
+    @NotBlank
     private String nomTravaux;
 
-    /** Date de début. */
-    @Column(nullable = false)
+    @NotNull
     private LocalDate dateDebut;
 
-    /** Date de fin. */
-    @Column(nullable = false)
+    @NotNull
     private LocalDate dateFin;
 
-    /** Assemblée générale concernée. */
     private String assembleeGenerale;
-
-    /** Clé de charges. */
     private String cleCharges;
-
-    /** Montant total des travaux. */
     private Double montantTravaux;
-
-    /** Nombre d'échéances de paiement. */
     private Integer nombreEcheances;
 
-    /** Détail des travaux. */
-    @Column(length = 3000, nullable = false)
+    @NotBlank
     private String details;
 
-    /** Références vers les images associées. */
-    @Column(length = 255)
     private String image1Ref;
-
-    @Column(length = 255)
     private String image2Ref;
-
-    @Column(length = 255)
     private String image3Ref;
-
-    // N–1 vers Carnet
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "carnet_id")
-    @JsonIgnore
-    private Carnet carnet;
 
     // ===== Getters / Setters =====
 
@@ -156,14 +129,6 @@ public class TravailImportant {
 
     public void setImage3Ref(String image3Ref) {
         this.image3Ref = image3Ref;
-    }
-
-    public Carnet getCarnet() {
-        return carnet;
-    }
-
-    public void setCarnet(Carnet carnet) {
-        this.carnet = carnet;
     }
 }
 

--- a/src/main/java/com/app/copro/exception/TravailImportantNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/TravailImportantNotFoundException.java
@@ -1,0 +1,8 @@
+package com.app.copro.exception;
+
+public class TravailImportantNotFoundException extends RuntimeException {
+    public TravailImportantNotFoundException(Long id) {
+        super("Travail important not found with id " + id);
+    }
+}
+

--- a/src/main/java/com/app/copro/repository/CarnetRepository.java
+++ b/src/main/java/com/app/copro/repository/CarnetRepository.java
@@ -12,5 +12,5 @@ public interface CarnetRepository extends JpaRepository<Carnet, Long> {
     List<Carnet> findBySyndic_Projet_IdMakePlan(Long idMakePlan);
     Optional<Carnet> findBySyndic_IsActiveTrue();
     Optional<Carnet> findFirstBySyndic_Projet_IdMakePlanAndSyndic_IsActiveTrueOrderByIdAsc(Long idMakePlan);
-    Optional<Carnet> findTopBySyndic_Projet_IdOrderByVersionDesc(Long projetId);
+    Optional<Carnet> findTopBySyndic_Projet_IdMakePlanOrderByVersionDesc(Long idMakePlan);
 }

--- a/src/main/java/com/app/copro/repository/CarnetRepository.java
+++ b/src/main/java/com/app/copro/repository/CarnetRepository.java
@@ -12,4 +12,5 @@ public interface CarnetRepository extends JpaRepository<Carnet, Long> {
     List<Carnet> findBySyndic_Projet_IdMakePlan(Long idMakePlan);
     Optional<Carnet> findBySyndic_IsActiveTrue();
     Optional<Carnet> findFirstBySyndic_Projet_IdMakePlanAndSyndic_IsActiveTrueOrderByIdAsc(Long idMakePlan);
+    Optional<Carnet> findTopBySyndic_Projet_IdOrderByVersionDesc(Long projetId);
 }

--- a/src/main/java/com/app/copro/repository/SyndicRepository.java
+++ b/src/main/java/com/app/copro/repository/SyndicRepository.java
@@ -24,4 +24,5 @@ public interface SyndicRepository extends JpaRepository<Syndic, Long> {
     List<Syndic> findActiveSyndicsByProjetIdMakePlan(@Param("idMakePlan") Long idMakePlan);
 
     Optional<Syndic> findByIsActiveTrue();
+    Optional<Syndic> findByProjet_IdAndIsActiveTrue(Long projetId);
 }

--- a/src/main/java/com/app/copro/repository/SyndicRepository.java
+++ b/src/main/java/com/app/copro/repository/SyndicRepository.java
@@ -24,5 +24,5 @@ public interface SyndicRepository extends JpaRepository<Syndic, Long> {
     List<Syndic> findActiveSyndicsByProjetIdMakePlan(@Param("idMakePlan") Long idMakePlan);
 
     Optional<Syndic> findByIsActiveTrue();
-    Optional<Syndic> findByProjet_IdAndIsActiveTrue(Long projetId);
+    Optional<Syndic> findByProjet_IdMakePlanAndIsActiveTrue(Long idMakePlan);
 }

--- a/src/main/java/com/app/copro/repository/TravailImportantRepository.java
+++ b/src/main/java/com/app/copro/repository/TravailImportantRepository.java
@@ -1,0 +1,11 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.TravailImportant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TravailImportantRepository extends JpaRepository<TravailImportant, Long> {
+    List<TravailImportant> findByCarnetId(Long carnetId);
+}
+

--- a/src/main/java/com/app/copro/service/CarnetService.java
+++ b/src/main/java/com/app/copro/service/CarnetService.java
@@ -19,11 +19,11 @@ public class CarnetService {
         this.syndicRepository = syndicRepository;
     }
 
-    public Carnet createCarnet(Long projetId) {
-        Syndic activeSyndic = syndicRepository.findByProjet_IdAndIsActiveTrue(projetId)
+    public Carnet createCarnet(Long idMakePlan) {
+        Syndic activeSyndic = syndicRepository.findByProjet_IdMakePlanAndIsActiveTrue(idMakePlan)
                 .orElseThrow(() -> new RuntimeException("Aucun syndic actif trouvé pour ce projet"));
         long nextVersion = carnetRepository
-                .findTopBySyndic_Projet_IdOrderByVersionDesc(projetId)
+                .findTopBySyndic_Projet_IdMakePlanOrderByVersionDesc(idMakePlan)
                 .map(c -> c.getVersion() + 1)
                 .orElse(1L);
         Carnet carnet = new Carnet();

--- a/src/main/java/com/app/copro/service/CarnetService.java
+++ b/src/main/java/com/app/copro/service/CarnetService.java
@@ -19,11 +19,16 @@ public class CarnetService {
         this.syndicRepository = syndicRepository;
     }
 
-    public Carnet createCarnet() {
-        Syndic activeSyndic = syndicRepository.findByIsActiveTrue()
-                .orElseThrow(() -> new RuntimeException("Aucun syndic actif trouvé"));
+    public Carnet createCarnet(Long projetId) {
+        Syndic activeSyndic = syndicRepository.findByProjet_IdAndIsActiveTrue(projetId)
+                .orElseThrow(() -> new RuntimeException("Aucun syndic actif trouvé pour ce projet"));
+        long nextVersion = carnetRepository
+                .findTopBySyndic_Projet_IdOrderByVersionDesc(projetId)
+                .map(c -> c.getVersion() + 1)
+                .orElse(1L);
         Carnet carnet = new Carnet();
         carnet.setSyndic(activeSyndic);
+        carnet.setVersion(nextVersion);
         return carnetRepository.save(carnet);
     }
 

--- a/src/main/java/com/app/copro/service/TravailImportantFileService.java
+++ b/src/main/java/com/app/copro/service/TravailImportantFileService.java
@@ -1,0 +1,63 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.exception.TravailImportantNotFoundException;
+import com.app.copro.model.TravailImportant;
+import com.app.copro.repository.TravailImportantRepository;
+import com.app.copro.util.FileConstants;
+import com.app.copro.util.FileManagerHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+public class TravailImportantFileService {
+
+    @Autowired
+    private FileManagerHelper fileManagerHelper;
+
+    @Autowired
+    private TravailImportantRepository repository;
+
+    public String uploadImage(Long travailId, MultipartFile file, int index) {
+        TravailImportant travail = repository.findById(travailId)
+                .orElseThrow(() -> new TravailImportantNotFoundException(travailId));
+
+        String fileRef = fileManagerHelper.uploadEntityDocument(
+                file,
+                FileConstants.EntityTypes.TRAVAIL_IMPORTANT,
+                travail.getId(),
+                FileConstants.CommonCategories.IMAGE,
+                "Image " + index + " travail important"
+        );
+
+        if (fileRef != null) {
+            switch (index) {
+                case 1 -> travail.setImage1Ref(fileRef);
+                case 2 -> travail.setImage2Ref(fileRef);
+                case 3 -> travail.setImage3Ref(fileRef);
+            }
+            repository.save(travail);
+        }
+
+        return fileRef;
+    }
+
+    public FileResponseDto getImage(Long travailId, int index) {
+        Optional<TravailImportant> opt = repository.findById(travailId);
+        if (opt.isEmpty()) {
+            return null;
+        }
+        TravailImportant t = opt.get();
+        String ref = switch (index) {
+            case 1 -> t.getImage1Ref();
+            case 2 -> t.getImage2Ref();
+            case 3 -> t.getImage3Ref();
+            default -> null;
+        };
+        return fileManagerHelper.parseFileReference(ref);
+    }
+}
+

--- a/src/main/java/com/app/copro/service/TravailImportantService.java
+++ b/src/main/java/com/app/copro/service/TravailImportantService.java
@@ -1,0 +1,97 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.TravailImportantDto;
+import com.app.copro.exception.TravailImportantNotFoundException;
+import com.app.copro.model.Carnet;
+import com.app.copro.model.TravailImportant;
+import com.app.copro.repository.CarnetRepository;
+import com.app.copro.repository.TravailImportantRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TravailImportantService {
+
+    private final TravailImportantRepository repository;
+    private final CarnetRepository carnetRepository;
+
+    public TravailImportantService(TravailImportantRepository repository, CarnetRepository carnetRepository) {
+        this.repository = repository;
+        this.carnetRepository = carnetRepository;
+    }
+
+    @Transactional
+    public TravailImportantDto create(Long carnetId, TravailImportantDto dto) {
+        Carnet carnet = carnetRepository.findById(carnetId)
+                .orElseThrow(() -> new RuntimeException("Carnet not found"));
+        TravailImportant entity = new TravailImportant();
+        applyDtoToEntity(dto, entity);
+        entity.setCarnet(carnet);
+        TravailImportant saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<TravailImportantDto> getByCarnet(Long carnetId) {
+        return repository.findByCarnetId(carnetId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public TravailImportantDto getById(Long id) {
+        TravailImportant entity = repository.findById(id)
+                .orElseThrow(() -> new TravailImportantNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public TravailImportantDto update(Long id, TravailImportantDto dto) {
+        TravailImportant entity = repository.findById(id)
+                .orElseThrow(() -> new TravailImportantNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        TravailImportant saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new TravailImportantNotFoundException(id);
+        }
+        repository.deleteById(id);
+    }
+
+    private TravailImportantDto mapToDto(TravailImportant entity) {
+        TravailImportantDto dto = new TravailImportantDto();
+        dto.setId(entity.getId());
+        dto.setNomTravaux(entity.getNomTravaux());
+        dto.setDateDebut(entity.getDateDebut());
+        dto.setDateFin(entity.getDateFin());
+        dto.setAssembleeGenerale(entity.getAssembleeGenerale());
+        dto.setCleCharges(entity.getCleCharges());
+        dto.setMontantTravaux(entity.getMontantTravaux());
+        dto.setNombreEcheances(entity.getNombreEcheances());
+        dto.setDetails(entity.getDetails());
+        dto.setImage1Ref(entity.getImage1Ref());
+        dto.setImage2Ref(entity.getImage2Ref());
+        dto.setImage3Ref(entity.getImage3Ref());
+        return dto;
+    }
+
+    private void applyDtoToEntity(TravailImportantDto dto, TravailImportant entity) {
+        entity.setNomTravaux(dto.getNomTravaux());
+        entity.setDateDebut(dto.getDateDebut());
+        entity.setDateFin(dto.getDateFin());
+        entity.setAssembleeGenerale(dto.getAssembleeGenerale());
+        entity.setCleCharges(dto.getCleCharges());
+        entity.setMontantTravaux(dto.getMontantTravaux());
+        entity.setNombreEcheances(dto.getNombreEcheances());
+        entity.setDetails(dto.getDetails());
+        entity.setImage1Ref(dto.getImage1Ref());
+        entity.setImage2Ref(dto.getImage2Ref());
+        entity.setImage3Ref(dto.getImage3Ref());
+    }
+}
+

--- a/src/main/java/com/app/copro/util/FileConstants.java
+++ b/src/main/java/com/app/copro/util/FileConstants.java
@@ -12,6 +12,7 @@ public final class FileConstants {
         public static final String PROJET = "PROJET";
         public static final String CONTRAT_ASSURANCE = "CONTRAT_ASSURANCE";
         public static final String DIAGNOSTIC_COLLECTIF = "DIAGNOSTIC_COLLECTIF";
+        public static final String TRAVAIL_IMPORTANT = "TRAVAIL_IMPORTANT";
     }
 
     public static final class SyndicCategories {


### PR DESCRIPTION
## Summary
- expand TravailImportant entity with scheduling, charge, cost and image fields
- implement DTO, service, repository and controller for CRUD operations
- add file service and constants to upload up to three images per work item

## Testing
- `mvn -q -e test` *(fails: Network is unreachable fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ad1345bc832a85809a2213d23baa