### PR TITLE
Add PPT model and file upload APIs

### DIFF
--- a/src/main/java/com/app/copro/controller/PptController.java
+++ b/src/main/java/com/app/copro/controller/PptController.java
@@ -1,0 +1,54 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.PptDto;
+import com.app.copro.service.PptFileService;
+import com.app.copro.service.PptService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class PptController {
+
+    private final PptService service;
+    private final PptFileService fileService;
+
+    public PptController(PptService service, PptFileService fileService) {
+        this.service = service;
+        this.fileService = fileService;
+    }
+
+    @PostMapping(value = "/carnets/{carnetId}/ppt", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PptDto> create(@PathVariable Long carnetId,
+                                         @RequestPart("ppt") PptDto dto,
+                                         @RequestPart(value = "file", required = false) MultipartFile file) {
+        PptDto created = service.create(carnetId, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), file);
+            created.setFichierRef(ref);
+        }
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/carnets/{carnetId}/ppt")
+    public ResponseEntity<PptDto> get(@PathVariable Long carnetId) {
+        PptDto dto = service.getByCarnet(carnetId);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping(value = "/carnets/{carnetId}/ppt", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PptDto> update(@PathVariable Long carnetId,
+                                         @RequestPart("ppt") PptDto dto,
+                                         @RequestPart(value = "file", required = false) MultipartFile file) {
+        PptDto updated = service.update(carnetId, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(updated.getId(), file);
+            updated.setFichierRef(ref);
+        }
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/src/main/java/com/app/copro/dto/PptDto.java
+++ b/src/main/java/com/app/copro/dto/PptDto.java
@@ -1,0 +1,51 @@
+package com.app.copro.dto;
+
+import java.time.LocalDate;
+
+public class PptDto {
+    private Long id;
+    private String natureTravaux;
+    private LocalDate dateProjet;
+    private String detailProjet;
+    private String fichierRef;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNatureTravaux() {
+        return natureTravaux;
+    }
+
+    public void setNatureTravaux(String natureTravaux) {
+        this.natureTravaux = natureTravaux;
+    }
+
+    public LocalDate getDateProjet() {
+        return dateProjet;
+    }
+
+    public void setDateProjet(LocalDate dateProjet) {
+        this.dateProjet = dateProjet;
+    }
+
+    public String getDetailProjet() {
+        return detailProjet;
+    }
+
+    public void setDetailProjet(String detailProjet) {
+        this.detailProjet = detailProjet;
+    }
+
+    public String getFichierRef() {
+        return fichierRef;
+    }
+
+    public void setFichierRef(String fichierRef) {
+        this.fichierRef = fichierRef;
+    }
+}

--- a/src/main/java/com/app/copro/model/Carnet.java
+++ b/src/main/java/com/app/copro/model/Carnet.java
@@ -35,6 +35,10 @@ public class Carnet {
     @OneToOne(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private DonneesTechniques donneesTechniques;
 
+    // 1–1 Plan Pluriannuel de Travaux (PPT) (FK côté Ppt)
+    @OneToOne(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private Ppt ppt;
+
     // 1–N Contrats d'assurance (FK côté ContratAssurance)
     @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ContratAssurance> contrats = new ArrayList<>();
@@ -112,6 +116,14 @@ public class Carnet {
 
     public void setDonneesTechniques(DonneesTechniques donneesTechniques) {
         this.donneesTechniques = donneesTechniques;
+    }
+
+    public Ppt getPpt() {
+        return ppt;
+    }
+
+    public void setPpt(Ppt ppt) {
+        this.ppt = ppt;
     }
 
     public List<ContratAssurance> getContrats() {

--- a/src/main/java/com/app/copro/model/Ppt.java
+++ b/src/main/java/com/app/copro/model/Ppt.java
@@ -1,0 +1,78 @@
+package com.app.copro.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "ppt")
+public class Ppt {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nature_travaux")
+    private String natureTravaux;
+
+    @Column(name = "date_projet")
+    private LocalDate dateProjet;
+
+    @Column(name = "detail_projet", length = 1000)
+    private String detailProjet;
+
+    @Column(name = "fichier_ref", length = 255)
+    private String fichierRef;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "carnet_id", unique = true, nullable = false)
+    @JsonIgnore
+    private Carnet carnet;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNatureTravaux() {
+        return natureTravaux;
+    }
+
+    public void setNatureTravaux(String natureTravaux) {
+        this.natureTravaux = natureTravaux;
+    }
+
+    public LocalDate getDateProjet() {
+        return dateProjet;
+    }
+
+    public void setDateProjet(LocalDate dateProjet) {
+        this.dateProjet = dateProjet;
+    }
+
+    public String getDetailProjet() {
+        return detailProjet;
+    }
+
+    public void setDetailProjet(String detailProjet) {
+        this.detailProjet = detailProjet;
+    }
+
+    public String getFichierRef() {
+        return fichierRef;
+    }
+
+    public void setFichierRef(String fichierRef) {
+        this.fichierRef = fichierRef;
+    }
+
+    public Carnet getCarnet() {
+        return carnet;
+    }
+
+    public void setCarnet(Carnet carnet) {
+        this.carnet = carnet;
+    }
+}

--- a/src/main/java/com/app/copro/repository/PptRepository.java
+++ b/src/main/java/com/app/copro/repository/PptRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.Ppt;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PptRepository extends JpaRepository<Ppt, Long> {
+    Optional<Ppt> findByCarnetId(Long carnetId);
+}

--- a/src/main/java/com/app/copro/service/PptFileService.java
+++ b/src/main/java/com/app/copro/service/PptFileService.java
@@ -1,0 +1,46 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.model.Ppt;
+import com.app.copro.repository.PptRepository;
+import com.app.copro.util.FileConstants;
+import com.app.copro.util.FileManagerHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+public class PptFileService {
+
+    @Autowired
+    private FileManagerHelper fileManagerHelper;
+
+    @Autowired
+    private PptRepository repository;
+
+    public String uploadFile(Long pptId, MultipartFile file) {
+        Ppt ppt = repository.findById(pptId)
+                .orElseThrow(() -> new RuntimeException("PPT not found: " + pptId));
+
+        String fileRef = fileManagerHelper.uploadEntityDocument(
+                file,
+                FileConstants.EntityTypes.PPT,
+                ppt.getId(),
+                FileConstants.CommonCategories.DOCUMENT,
+                "Document PPT"
+        );
+
+        if (fileRef != null) {
+            ppt.setFichierRef(fileRef);
+            repository.save(ppt);
+        }
+        return fileRef;
+    }
+
+    public FileResponseDto getFile(Long pptId) {
+        Optional<Ppt> opt = repository.findById(pptId);
+        return opt.map(p -> fileManagerHelper.parseFileReference(p.getFichierRef())).orElse(null);
+    }
+}

--- a/src/main/java/com/app/copro/service/PptService.java
+++ b/src/main/java/com/app/copro/service/PptService.java
@@ -1,0 +1,69 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.PptDto;
+import com.app.copro.model.Carnet;
+import com.app.copro.model.Ppt;
+import com.app.copro.repository.CarnetRepository;
+import com.app.copro.repository.PptRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PptService {
+
+    private final PptRepository repository;
+    private final CarnetRepository carnetRepository;
+
+    public PptService(PptRepository repository, CarnetRepository carnetRepository) {
+        this.repository = repository;
+        this.carnetRepository = carnetRepository;
+    }
+
+    @Transactional
+    public PptDto create(Long carnetId, PptDto dto) {
+        Carnet carnet = carnetRepository.findById(carnetId)
+                .orElseThrow(() -> new RuntimeException("Carnet not found"));
+
+        if (repository.findByCarnetId(carnetId).isPresent()) {
+            throw new IllegalStateException("PPT already exists for this carnet");
+        }
+
+        Ppt entity = new Ppt();
+        applyDtoToEntity(dto, entity);
+        entity.setCarnet(carnet);
+        Ppt saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public PptDto getByCarnet(Long carnetId) {
+        Ppt entity = repository.findByCarnetId(carnetId)
+                .orElseThrow(() -> new RuntimeException("PPT not found for carnet " + carnetId));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public PptDto update(Long carnetId, PptDto dto) {
+        Ppt entity = repository.findByCarnetId(carnetId)
+                .orElseThrow(() -> new RuntimeException("PPT not found for carnet " + carnetId));
+        applyDtoToEntity(dto, entity);
+        Ppt saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    private PptDto mapToDto(Ppt entity) {
+        PptDto dto = new PptDto();
+        dto.setId(entity.getId());
+        dto.setNatureTravaux(entity.getNatureTravaux());
+        dto.setDateProjet(entity.getDateProjet());
+        dto.setDetailProjet(entity.getDetailProjet());
+        dto.setFichierRef(entity.getFichierRef());
+        return dto;
+    }
+
+    private void applyDtoToEntity(PptDto dto, Ppt entity) {
+        entity.setNatureTravaux(dto.getNatureTravaux());
+        entity.setDateProjet(dto.getDateProjet());
+        entity.setDetailProjet(dto.getDetailProjet());
+        entity.setFichierRef(dto.getFichierRef());
+    }
+}

--- a/src/main/java/com/app/copro/util/FileConstants.java
+++ b/src/main/java/com/app/copro/util/FileConstants.java
@@ -13,6 +13,7 @@ public final class FileConstants {
         public static final String CONTRAT_ASSURANCE = "CONTRAT_ASSURANCE";
         public static final String DIAGNOSTIC_COLLECTIF = "DIAGNOSTIC_COLLECTIF";
         public static final String TRAVAIL_IMPORTANT = "TRAVAIL_IMPORTANT";
+        public static final String PPT = "PPT";
     }
 
     public static final class SyndicCategories {


### PR DESCRIPTION
## Summary
- add PPT entity and DTO representing plan pluriannuel de travaux with one-to-one carnet relation
- expose controller endpoints to create, fetch, and update PPT records with optional file uploads
- support file storage for PPT via dedicated service and new FileConstants entry

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a641fa24832a90d80f4474bc5c5f