### PR TITLE
Add administrative procedure and damage-ouvrage contract entities

### DIFF
--- a/src/main/java/com/app/copro/controller/ContratDommageOuvrageController.java
+++ b/src/main/java/com/app/copro/controller/ContratDommageOuvrageController.java
@@ -1,0 +1,54 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.ContratDommageOuvrageDto;
+import com.app.copro.service.ContratDommageOuvrageService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class ContratDommageOuvrageController {
+
+    private final ContratDommageOuvrageService service;
+
+    public ContratDommageOuvrageController(ContratDommageOuvrageService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/carnets/{carnetId}/contrats-dommage-ouvrage")
+    public ResponseEntity<ContratDommageOuvrageDto> create(@PathVariable Long carnetId,
+                                                            @Valid @RequestBody ContratDommageOuvrageDto dto) {
+        ContratDommageOuvrageDto created = service.create(carnetId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/carnets/{carnetId}/contrats-dommage-ouvrage")
+    public ResponseEntity<List<ContratDommageOuvrageDto>> getByCarnet(@PathVariable Long carnetId) {
+        List<ContratDommageOuvrageDto> list = service.getByCarnet(carnetId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/contrats-dommage-ouvrage/{id}")
+    public ResponseEntity<ContratDommageOuvrageDto> getById(@PathVariable Long id) {
+        ContratDommageOuvrageDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/contrats-dommage-ouvrage/{id}")
+    public ResponseEntity<ContratDommageOuvrageDto> update(@PathVariable Long id,
+                                                            @Valid @RequestBody ContratDommageOuvrageDto dto) {
+        ContratDommageOuvrageDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/contrats-dommage-ouvrage/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/app/copro/controller/ProcedureAdministrativeController.java
+++ b/src/main/java/com/app/copro/controller/ProcedureAdministrativeController.java
@@ -1,0 +1,97 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.dto.ProcedureAdministrativeDto;
+import com.app.copro.service.ProcedureAdministrativeFileService;
+import com.app.copro.service.ProcedureAdministrativeService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class ProcedureAdministrativeController {
+
+    private final ProcedureAdministrativeService service;
+    private final ProcedureAdministrativeFileService fileService;
+
+    public ProcedureAdministrativeController(ProcedureAdministrativeService service,
+                                             ProcedureAdministrativeFileService fileService) {
+        this.service = service;
+        this.fileService = fileService;
+    }
+
+    @PostMapping("/carnets/{carnetId}/procedures-administratives")
+    public ResponseEntity<ProcedureAdministrativeDto> create(@PathVariable Long carnetId,
+                                                             @Valid @RequestBody ProcedureAdministrativeDto dto) {
+        ProcedureAdministrativeDto created = service.create(carnetId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/carnets/{carnetId}/procedures-administratives/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ProcedureAdministrativeDto> createWithFile(@PathVariable Long carnetId,
+                                                                     @RequestPart("procedure") @Valid ProcedureAdministrativeDto dto,
+                                                                     @RequestPart(value = "file", required = false) MultipartFile file) {
+        ProcedureAdministrativeDto created = service.create(carnetId, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), file);
+            created.setFichierRef(ref);
+        }
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/carnets/{carnetId}/procedures-administratives")
+    public ResponseEntity<List<ProcedureAdministrativeDto>> getByCarnet(@PathVariable Long carnetId) {
+        List<ProcedureAdministrativeDto> list = service.getByCarnet(carnetId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/procedures-administratives/{id}")
+    public ResponseEntity<ProcedureAdministrativeDto> getById(@PathVariable Long id) {
+        ProcedureAdministrativeDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/procedures-administratives/{id}")
+    public ResponseEntity<ProcedureAdministrativeDto> update(@PathVariable Long id,
+                                                             @Valid @RequestBody ProcedureAdministrativeDto dto) {
+        ProcedureAdministrativeDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @PutMapping(value = "/procedures-administratives/{id}/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ProcedureAdministrativeDto> updateWithFile(@PathVariable Long id,
+                                                                     @RequestPart("procedure") @Valid ProcedureAdministrativeDto dto,
+                                                                     @RequestPart(value = "file", required = false) MultipartFile file) {
+        ProcedureAdministrativeDto updated = service.update(id, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(updated.getId(), file);
+            updated.setFichierRef(ref);
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/procedures-administratives/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/procedures-administratives/{id}/file")
+    public ResponseEntity<String> uploadFile(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+        String ref = fileService.uploadFile(id, file);
+        return ref != null ? ResponseEntity.ok(ref) : ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/procedures-administratives/{id}/file")
+    public ResponseEntity<FileResponseDto> getFile(@PathVariable Long id) {
+        FileResponseDto file = fileService.getFile(id);
+        return file != null ? ResponseEntity.ok(file) : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/app/copro/dto/ContratDommageOuvrageDto.java
+++ b/src/main/java/com/app/copro/dto/ContratDommageOuvrageDto.java
@@ -1,0 +1,52 @@
+package com.app.copro.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+public class ContratDommageOuvrageDto {
+    private Long id;
+
+    @NotBlank
+    private String contrat;
+
+    @NotBlank
+    private String assureur;
+
+    private String compagnie;
+    private String numeroContrat;
+    private String numeroPolice;
+    private LocalDate dateEffet;
+    private LocalDate dateFin;
+    private Long travailId;
+    private String souscripteur;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getContrat() { return contrat; }
+    public void setContrat(String contrat) { this.contrat = contrat; }
+
+    public String getAssureur() { return assureur; }
+    public void setAssureur(String assureur) { this.assureur = assureur; }
+
+    public String getCompagnie() { return compagnie; }
+    public void setCompagnie(String compagnie) { this.compagnie = compagnie; }
+
+    public String getNumeroContrat() { return numeroContrat; }
+    public void setNumeroContrat(String numeroContrat) { this.numeroContrat = numeroContrat; }
+
+    public String getNumeroPolice() { return numeroPolice; }
+    public void setNumeroPolice(String numeroPolice) { this.numeroPolice = numeroPolice; }
+
+    public LocalDate getDateEffet() { return dateEffet; }
+    public void setDateEffet(LocalDate dateEffet) { this.dateEffet = dateEffet; }
+
+    public LocalDate getDateFin() { return dateFin; }
+    public void setDateFin(LocalDate dateFin) { this.dateFin = dateFin; }
+
+    public Long getTravailId() { return travailId; }
+    public void setTravailId(Long travailId) { this.travailId = travailId; }
+
+    public String getSouscripteur() { return souscripteur; }
+    public void setSouscripteur(String souscripteur) { this.souscripteur = souscripteur; }
+}

--- a/src/main/java/com/app/copro/dto/ProcedureAdministrativeDto.java
+++ b/src/main/java/com/app/copro/dto/ProcedureAdministrativeDto.java
@@ -1,0 +1,40 @@
+package com.app.copro.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+
+public class ProcedureAdministrativeDto {
+    private Long id;
+
+    @NotBlank
+    private String typeProcedure;
+
+    @NotBlank
+    private String libelle;
+
+    private LocalDate dateArrete;
+    private LocalDate dateMainlevee;
+    private String description;
+    private String fichierRef;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getTypeProcedure() { return typeProcedure; }
+    public void setTypeProcedure(String typeProcedure) { this.typeProcedure = typeProcedure; }
+
+    public String getLibelle() { return libelle; }
+    public void setLibelle(String libelle) { this.libelle = libelle; }
+
+    public LocalDate getDateArrete() { return dateArrete; }
+    public void setDateArrete(LocalDate dateArrete) { this.dateArrete = dateArrete; }
+
+    public LocalDate getDateMainlevee() { return dateMainlevee; }
+    public void setDateMainlevee(LocalDate dateMainlevee) { this.dateMainlevee = dateMainlevee; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getFichierRef() { return fichierRef; }
+    public void setFichierRef(String fichierRef) { this.fichierRef = fichierRef; }
+}

--- a/src/main/java/com/app/copro/exception/ContratDommageOuvrageNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/ContratDommageOuvrageNotFoundException.java
@@ -1,0 +1,7 @@
+package com.app.copro.exception;
+
+public class ContratDommageOuvrageNotFoundException extends RuntimeException {
+    public ContratDommageOuvrageNotFoundException(Long id) {
+        super("Contrat dommage-ouvrage not found with id " + id);
+    }
+}

--- a/src/main/java/com/app/copro/exception/ProcedureAdministrativeNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/ProcedureAdministrativeNotFoundException.java
@@ -1,0 +1,7 @@
+package com.app.copro.exception;
+
+public class ProcedureAdministrativeNotFoundException extends RuntimeException {
+    public ProcedureAdministrativeNotFoundException(Long id) {
+        super("Procédure administrative not found with id " + id);
+    }
+}

--- a/src/main/java/com/app/copro/model/Carnet.java
+++ b/src/main/java/com/app/copro/model/Carnet.java
@@ -43,6 +43,14 @@ public class Carnet {
     @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ContratAssurance> contrats = new ArrayList<>();
 
+    // 1–N Contrats dommages-ouvrage (FK côté ContratDommageOuvrage)
+    @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ContratDommageOuvrage> contratsDommageOuvrage = new ArrayList<>();
+
+    // 1–N Procédures administratives (FK côté ProcedureAdministrative)
+    @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProcedureAdministrative> proceduresAdministratives = new ArrayList<>();
+
     // 1–N Travaux importants (FK côté TravailImportant)
     @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<TravailImportant> travauxImportants = new ArrayList<>();
@@ -132,6 +140,22 @@ public class Carnet {
 
     public void setContrats(List<ContratAssurance> contrats) {
         this.contrats = contrats;
+    }
+
+    public List<ContratDommageOuvrage> getContratsDommageOuvrage() {
+        return contratsDommageOuvrage;
+    }
+
+    public void setContratsDommageOuvrage(List<ContratDommageOuvrage> contratsDommageOuvrage) {
+        this.contratsDommageOuvrage = contratsDommageOuvrage;
+    }
+
+    public List<ProcedureAdministrative> getProceduresAdministratives() {
+        return proceduresAdministratives;
+    }
+
+    public void setProceduresAdministratives(List<ProcedureAdministrative> proceduresAdministratives) {
+        this.proceduresAdministratives = proceduresAdministratives;
     }
 
     public List<TravailImportant> getTravauxImportants() {

--- a/src/main/java/com/app/copro/model/ContratDommageOuvrage.java
+++ b/src/main/java/com/app/copro/model/ContratDommageOuvrage.java
@@ -1,0 +1,88 @@
+package com.app.copro.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+/**
+ * Contrat d'assurance dommages-ouvrage.
+ */
+@Entity
+@Table(name = "contrat_dommage_ouvrage")
+public class ContratDommageOuvrage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Type de contrat (ex. Dommage-ouvrage). */
+    @Column(nullable = false)
+    private String contrat;
+
+    /** Assureur sélectionné. */
+    @Column(nullable = false)
+    private String assureur;
+
+    /** Compagnie. */
+    private String compagnie;
+
+    /** Numéro de contrat. */
+    private String numeroContrat;
+
+    /** Numéro de police. */
+    private String numeroPolice;
+
+    /** Date d'effet du contrat. */
+    private LocalDate dateEffet;
+
+    /** Date de fin du contrat. */
+    private LocalDate dateFin;
+
+    /** Référence vers les travaux concernés (optionnel). */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travail_id")
+    private TravailImportant travail;
+
+    /** Souscripteur du contrat. */
+    private String souscripteur;
+
+    // Relation N-1 vers Carnet
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "carnet_id")
+    @JsonIgnore
+    private Carnet carnet;
+
+    // ===== Getters / Setters =====
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getContrat() { return contrat; }
+    public void setContrat(String contrat) { this.contrat = contrat; }
+
+    public String getAssureur() { return assureur; }
+    public void setAssureur(String assureur) { this.assureur = assureur; }
+
+    public String getCompagnie() { return compagnie; }
+    public void setCompagnie(String compagnie) { this.compagnie = compagnie; }
+
+    public String getNumeroContrat() { return numeroContrat; }
+    public void setNumeroContrat(String numeroContrat) { this.numeroContrat = numeroContrat; }
+
+    public String getNumeroPolice() { return numeroPolice; }
+    public void setNumeroPolice(String numeroPolice) { this.numeroPolice = numeroPolice; }
+
+    public LocalDate getDateEffet() { return dateEffet; }
+    public void setDateEffet(LocalDate dateEffet) { this.dateEffet = dateEffet; }
+
+    public LocalDate getDateFin() { return dateFin; }
+    public void setDateFin(LocalDate dateFin) { this.dateFin = dateFin; }
+
+    public TravailImportant getTravail() { return travail; }
+    public void setTravail(TravailImportant travail) { this.travail = travail; }
+
+    public String getSouscripteur() { return souscripteur; }
+    public void setSouscripteur(String souscripteur) { this.souscripteur = souscripteur; }
+
+    public Carnet getCarnet() { return carnet; }
+    public void setCarnet(Carnet carnet) { this.carnet = carnet; }
+}

--- a/src/main/java/com/app/copro/model/ProcedureAdministrative.java
+++ b/src/main/java/com/app/copro/model/ProcedureAdministrative.java
@@ -1,0 +1,70 @@
+package com.app.copro.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+/**
+ * Entité représentant une procédure administrative ou juridique.
+ */
+@Entity
+@Table(name = "procedure_administrative")
+public class ProcedureAdministrative {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Type de procédure (ex. Arrêté relevant du code de la santé publique). */
+    @Column(nullable = false)
+    private String typeProcedure;
+
+    /** Libellé de la procédure. */
+    @Column(nullable = false)
+    private String libelle;
+
+    /** Date de l'arrêté. */
+    private LocalDate dateArrete;
+
+    /** Date de mainlevée. */
+    private LocalDate dateMainlevee;
+
+    /** Description détaillée. */
+    @Column(length = 3000)
+    private String description;
+
+    /** Référence vers le fichier associé. */
+    @Column(length = 255)
+    private String fichierRef;
+
+    // Relation N-1 vers Carnet
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "carnet_id")
+    @JsonIgnore
+    private Carnet carnet;
+
+    // ===== Getters / Setters =====
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getTypeProcedure() { return typeProcedure; }
+    public void setTypeProcedure(String typeProcedure) { this.typeProcedure = typeProcedure; }
+
+    public String getLibelle() { return libelle; }
+    public void setLibelle(String libelle) { this.libelle = libelle; }
+
+    public LocalDate getDateArrete() { return dateArrete; }
+    public void setDateArrete(LocalDate dateArrete) { this.dateArrete = dateArrete; }
+
+    public LocalDate getDateMainlevee() { return dateMainlevee; }
+    public void setDateMainlevee(LocalDate dateMainlevee) { this.dateMainlevee = dateMainlevee; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getFichierRef() { return fichierRef; }
+    public void setFichierRef(String fichierRef) { this.fichierRef = fichierRef; }
+
+    public Carnet getCarnet() { return carnet; }
+    public void setCarnet(Carnet carnet) { this.carnet = carnet; }
+}

--- a/src/main/java/com/app/copro/repository/ContratDommageOuvrageRepository.java
+++ b/src/main/java/com/app/copro/repository/ContratDommageOuvrageRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.ContratDommageOuvrage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ContratDommageOuvrageRepository extends JpaRepository<ContratDommageOuvrage, Long> {
+    List<ContratDommageOuvrage> findByCarnetId(Long carnetId);
+}

--- a/src/main/java/com/app/copro/repository/ProcedureAdministrativeRepository.java
+++ b/src/main/java/com/app/copro/repository/ProcedureAdministrativeRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.ProcedureAdministrative;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProcedureAdministrativeRepository extends JpaRepository<ProcedureAdministrative, Long> {
+    List<ProcedureAdministrative> findByCarnetId(Long carnetId);
+}

--- a/src/main/java/com/app/copro/service/ContratDommageOuvrageService.java
+++ b/src/main/java/com/app/copro/service/ContratDommageOuvrageService.java
@@ -1,0 +1,104 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.ContratDommageOuvrageDto;
+import com.app.copro.exception.ContratDommageOuvrageNotFoundException;
+import com.app.copro.model.Carnet;
+import com.app.copro.model.ContratDommageOuvrage;
+import com.app.copro.model.TravailImportant;
+import com.app.copro.repository.CarnetRepository;
+import com.app.copro.repository.ContratDommageOuvrageRepository;
+import com.app.copro.repository.TravailImportantRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ContratDommageOuvrageService {
+
+    private final ContratDommageOuvrageRepository repository;
+    private final CarnetRepository carnetRepository;
+    private final TravailImportantRepository travailRepository;
+
+    public ContratDommageOuvrageService(ContratDommageOuvrageRepository repository,
+                                        CarnetRepository carnetRepository,
+                                        TravailImportantRepository travailRepository) {
+        this.repository = repository;
+        this.carnetRepository = carnetRepository;
+        this.travailRepository = travailRepository;
+    }
+
+    @Transactional
+    public ContratDommageOuvrageDto create(Long carnetId, ContratDommageOuvrageDto dto) {
+        Carnet carnet = carnetRepository.findById(carnetId)
+                .orElseThrow(() -> new RuntimeException("Carnet not found"));
+        ContratDommageOuvrage entity = new ContratDommageOuvrage();
+        applyDtoToEntity(dto, entity);
+        entity.setCarnet(carnet);
+        ContratDommageOuvrage saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<ContratDommageOuvrageDto> getByCarnet(Long carnetId) {
+        return repository.findByCarnetId(carnetId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public ContratDommageOuvrageDto getById(Long id) {
+        ContratDommageOuvrage entity = repository.findById(id)
+                .orElseThrow(() -> new ContratDommageOuvrageNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public ContratDommageOuvrageDto update(Long id, ContratDommageOuvrageDto dto) {
+        ContratDommageOuvrage entity = repository.findById(id)
+                .orElseThrow(() -> new ContratDommageOuvrageNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        ContratDommageOuvrage saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new ContratDommageOuvrageNotFoundException(id);
+        }
+        repository.deleteById(id);
+    }
+
+    private ContratDommageOuvrageDto mapToDto(ContratDommageOuvrage entity) {
+        ContratDommageOuvrageDto dto = new ContratDommageOuvrageDto();
+        dto.setId(entity.getId());
+        dto.setContrat(entity.getContrat());
+        dto.setAssureur(entity.getAssureur());
+        dto.setCompagnie(entity.getCompagnie());
+        dto.setNumeroContrat(entity.getNumeroContrat());
+        dto.setNumeroPolice(entity.getNumeroPolice());
+        dto.setDateEffet(entity.getDateEffet());
+        dto.setDateFin(entity.getDateFin());
+        dto.setTravailId(entity.getTravail() != null ? entity.getTravail().getId() : null);
+        dto.setSouscripteur(entity.getSouscripteur());
+        return dto;
+    }
+
+    private void applyDtoToEntity(ContratDommageOuvrageDto dto, ContratDommageOuvrage entity) {
+        entity.setContrat(dto.getContrat());
+        entity.setAssureur(dto.getAssureur());
+        entity.setCompagnie(dto.getCompagnie());
+        entity.setNumeroContrat(dto.getNumeroContrat());
+        entity.setNumeroPolice(dto.getNumeroPolice());
+        entity.setDateEffet(dto.getDateEffet());
+        entity.setDateFin(dto.getDateFin());
+        entity.setSouscripteur(dto.getSouscripteur());
+        if (dto.getTravailId() != null) {
+            TravailImportant travail = travailRepository.findById(dto.getTravailId())
+                    .orElse(null);
+            entity.setTravail(travail);
+        } else {
+            entity.setTravail(null);
+        }
+    }
+}

--- a/src/main/java/com/app/copro/service/ProcedureAdministrativeFileService.java
+++ b/src/main/java/com/app/copro/service/ProcedureAdministrativeFileService.java
@@ -1,0 +1,47 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.exception.ProcedureAdministrativeNotFoundException;
+import com.app.copro.model.ProcedureAdministrative;
+import com.app.copro.repository.ProcedureAdministrativeRepository;
+import com.app.copro.util.FileConstants;
+import com.app.copro.util.FileManagerHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+public class ProcedureAdministrativeFileService {
+
+    @Autowired
+    private FileManagerHelper fileManagerHelper;
+
+    @Autowired
+    private ProcedureAdministrativeRepository repository;
+
+    public String uploadFile(Long procedureId, MultipartFile file) {
+        ProcedureAdministrative procedure = repository.findById(procedureId)
+                .orElseThrow(() -> new ProcedureAdministrativeNotFoundException(procedureId));
+
+        String fileRef = fileManagerHelper.uploadEntityDocument(
+                file,
+                FileConstants.EntityTypes.PROCEDURE_ADMINISTRATIVE,
+                procedure.getId(),
+                FileConstants.CommonCategories.DOCUMENT,
+                "Document procédure administrative"
+        );
+
+        if (fileRef != null) {
+            procedure.setFichierRef(fileRef);
+            repository.save(procedure);
+        }
+        return fileRef;
+    }
+
+    public FileResponseDto getFile(Long procedureId) {
+        Optional<ProcedureAdministrative> opt = repository.findById(procedureId);
+        return opt.map(p -> fileManagerHelper.parseFileReference(p.getFichierRef())).orElse(null);
+    }
+}

--- a/src/main/java/com/app/copro/service/ProcedureAdministrativeService.java
+++ b/src/main/java/com/app/copro/service/ProcedureAdministrativeService.java
@@ -1,0 +1,86 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.ProcedureAdministrativeDto;
+import com.app.copro.exception.ProcedureAdministrativeNotFoundException;
+import com.app.copro.model.Carnet;
+import com.app.copro.model.ProcedureAdministrative;
+import com.app.copro.repository.CarnetRepository;
+import com.app.copro.repository.ProcedureAdministrativeRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ProcedureAdministrativeService {
+
+    private final ProcedureAdministrativeRepository repository;
+    private final CarnetRepository carnetRepository;
+
+    public ProcedureAdministrativeService(ProcedureAdministrativeRepository repository, CarnetRepository carnetRepository) {
+        this.repository = repository;
+        this.carnetRepository = carnetRepository;
+    }
+
+    @Transactional
+    public ProcedureAdministrativeDto create(Long carnetId, ProcedureAdministrativeDto dto) {
+        Carnet carnet = carnetRepository.findById(carnetId)
+                .orElseThrow(() -> new RuntimeException("Carnet not found"));
+        ProcedureAdministrative entity = new ProcedureAdministrative();
+        applyDtoToEntity(dto, entity);
+        entity.setCarnet(carnet);
+        ProcedureAdministrative saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<ProcedureAdministrativeDto> getByCarnet(Long carnetId) {
+        return repository.findByCarnetId(carnetId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public ProcedureAdministrativeDto getById(Long id) {
+        ProcedureAdministrative entity = repository.findById(id)
+                .orElseThrow(() -> new ProcedureAdministrativeNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public ProcedureAdministrativeDto update(Long id, ProcedureAdministrativeDto dto) {
+        ProcedureAdministrative entity = repository.findById(id)
+                .orElseThrow(() -> new ProcedureAdministrativeNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        ProcedureAdministrative saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new ProcedureAdministrativeNotFoundException(id);
+        }
+        repository.deleteById(id);
+    }
+
+    private ProcedureAdministrativeDto mapToDto(ProcedureAdministrative entity) {
+        ProcedureAdministrativeDto dto = new ProcedureAdministrativeDto();
+        dto.setId(entity.getId());
+        dto.setTypeProcedure(entity.getTypeProcedure());
+        dto.setLibelle(entity.getLibelle());
+        dto.setDateArrete(entity.getDateArrete());
+        dto.setDateMainlevee(entity.getDateMainlevee());
+        dto.setDescription(entity.getDescription());
+        dto.setFichierRef(entity.getFichierRef());
+        return dto;
+    }
+
+    private void applyDtoToEntity(ProcedureAdministrativeDto dto, ProcedureAdministrative entity) {
+        entity.setTypeProcedure(dto.getTypeProcedure());
+        entity.setLibelle(dto.getLibelle());
+        entity.setDateArrete(dto.getDateArrete());
+        entity.setDateMainlevee(dto.getDateMainlevee());
+        entity.setDescription(dto.getDescription());
+        entity.setFichierRef(dto.getFichierRef());
+    }
+}

--- a/src/main/java/com/app/copro/util/FileConstants.java
+++ b/src/main/java/com/app/copro/util/FileConstants.java
@@ -13,6 +13,7 @@ public final class FileConstants {
         public static final String CONTRAT_ASSURANCE = "CONTRAT_ASSURANCE";
         public static final String DIAGNOSTIC_COLLECTIF = "DIAGNOSTIC_COLLECTIF";
         public static final String TRAVAIL_IMPORTANT = "TRAVAIL_IMPORTANT";
+        public static final String PROCEDURE_ADMINISTRATIVE = "PROCEDURE_ADMINISTRATIVE";
         public static final String PPT = "PPT";
     }
 


### PR DESCRIPTION
## Summary
- add ProcedureAdministrative entity with file upload API and Carnet linkage
- add ContratDommageOuvrage entity without file handling plus related API
- extend Carnet and file constants for new relationships

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b10f15f0832aad7303293220fe16