### PR TITLE
Add Chapitre entity and CRUD endpoints

### DIFF
--- a/src/main/java/com/app/copro/controller/ChapitreController.java
+++ b/src/main/java/com/app/copro/controller/ChapitreController.java
@@ -1,0 +1,49 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.ChapitreDto;
+import com.app.copro.service.ChapitreService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class ChapitreController {
+
+    private final ChapitreService service;
+
+    public ChapitreController(ChapitreService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/carnets/{carnetId}/chapitres")
+    public ResponseEntity<ChapitreDto> create(@PathVariable Long carnetId,
+                                              @Valid @RequestBody ChapitreDto dto) {
+        ChapitreDto created = service.create(carnetId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/chapitres/{id}")
+    public ResponseEntity<ChapitreDto> update(@PathVariable Long id,
+                                              @Valid @RequestBody ChapitreDto dto) {
+        ChapitreDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @GetMapping("/carnets/{carnetId}/chapitres")
+    public ResponseEntity<List<ChapitreDto>> getByCarnet(@PathVariable Long carnetId) {
+        List<ChapitreDto> list = service.getByCarnet(carnetId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/chapitres/{id}")
+    public ResponseEntity<ChapitreDto> getById(@PathVariable Long id) {
+        ChapitreDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+}
+

--- a/src/main/java/com/app/copro/dto/ChapitreDto.java
+++ b/src/main/java/com/app/copro/dto/ChapitreDto.java
@@ -1,0 +1,42 @@
+package com.app.copro.dto;
+
+public class ChapitreDto {
+
+    private Long id;
+    private Long idBatiment;
+    private String nom;
+    private String adresse;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getIdBatiment() {
+        return idBatiment;
+    }
+
+    public void setIdBatiment(Long idBatiment) {
+        this.idBatiment = idBatiment;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+
+    public void setNom(String nom) {
+        this.nom = nom;
+    }
+
+    public String getAdresse() {
+        return adresse;
+    }
+
+    public void setAdresse(String adresse) {
+        this.adresse = adresse;
+    }
+}
+

--- a/src/main/java/com/app/copro/exception/ChapitreNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/ChapitreNotFoundException.java
@@ -1,0 +1,8 @@
+package com.app.copro.exception;
+
+public class ChapitreNotFoundException extends RuntimeException {
+    public ChapitreNotFoundException(Long id) {
+        super("Chapitre not found with id " + id);
+    }
+}
+

--- a/src/main/java/com/app/copro/model/Carnet.java
+++ b/src/main/java/com/app/copro/model/Carnet.java
@@ -59,6 +59,10 @@ public class Carnet {
     @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DiagnosticCollectif> diagnosticsCollectifs = new ArrayList<>();
 
+    // 1–N Chapitres (FK côté Chapitre)
+    @OneToMany(mappedBy = "carnet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Chapitre> chapitres = new ArrayList<>();
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();
@@ -172,5 +176,13 @@ public class Carnet {
 
     public void setDiagnosticsCollectifs(List<DiagnosticCollectif> diagnosticsCollectifs) {
         this.diagnosticsCollectifs = diagnosticsCollectifs;
+    }
+
+    public List<Chapitre> getChapitres() {
+        return chapitres;
+    }
+
+    public void setChapitres(List<Chapitre> chapitres) {
+        this.chapitres = chapitres;
     }
 }

--- a/src/main/java/com/app/copro/model/Chapitre.java
+++ b/src/main/java/com/app/copro/model/Chapitre.java
@@ -1,0 +1,66 @@
+package com.app.copro.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "chapitre")
+public class Chapitre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "id_batiment")
+    private Long idBatiment;
+
+    private String nom;
+
+    private String adresse;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "carnet_id")
+    @JsonIgnore
+    private Carnet carnet;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getIdBatiment() {
+        return idBatiment;
+    }
+
+    public void setIdBatiment(Long idBatiment) {
+        this.idBatiment = idBatiment;
+    }
+
+    public String getNom() {
+        return nom;
+    }
+
+    public void setNom(String nom) {
+        this.nom = nom;
+    }
+
+    public String getAdresse() {
+        return adresse;
+    }
+
+    public void setAdresse(String adresse) {
+        this.adresse = adresse;
+    }
+
+    public Carnet getCarnet() {
+        return carnet;
+    }
+
+    public void setCarnet(Carnet carnet) {
+        this.carnet = carnet;
+    }
+}
+

--- a/src/main/java/com/app/copro/repository/ChapitreRepository.java
+++ b/src/main/java/com/app/copro/repository/ChapitreRepository.java
@@ -1,0 +1,11 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.Chapitre;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChapitreRepository extends JpaRepository<Chapitre, Long> {
+    List<Chapitre> findByCarnetId(Long carnetId);
+}
+

--- a/src/main/java/com/app/copro/service/ChapitreService.java
+++ b/src/main/java/com/app/copro/service/ChapitreService.java
@@ -1,0 +1,73 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.ChapitreDto;
+import com.app.copro.exception.ChapitreNotFoundException;
+import com.app.copro.model.Carnet;
+import com.app.copro.model.Chapitre;
+import com.app.copro.repository.CarnetRepository;
+import com.app.copro.repository.ChapitreRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ChapitreService {
+
+    private final ChapitreRepository repository;
+    private final CarnetRepository carnetRepository;
+
+    public ChapitreService(ChapitreRepository repository, CarnetRepository carnetRepository) {
+        this.repository = repository;
+        this.carnetRepository = carnetRepository;
+    }
+
+    @Transactional
+    public ChapitreDto create(Long carnetId, ChapitreDto dto) {
+        Carnet carnet = carnetRepository.findById(carnetId)
+                .orElseThrow(() -> new RuntimeException("Carnet not found"));
+        Chapitre entity = new Chapitre();
+        applyDtoToEntity(dto, entity);
+        entity.setCarnet(carnet);
+        Chapitre saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<ChapitreDto> getByCarnet(Long carnetId) {
+        return repository.findByCarnetId(carnetId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public ChapitreDto getById(Long id) {
+        Chapitre entity = repository.findById(id)
+                .orElseThrow(() -> new ChapitreNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public ChapitreDto update(Long id, ChapitreDto dto) {
+        Chapitre entity = repository.findById(id)
+                .orElseThrow(() -> new ChapitreNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        Chapitre saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    private ChapitreDto mapToDto(Chapitre entity) {
+        ChapitreDto dto = new ChapitreDto();
+        dto.setId(entity.getId());
+        dto.setIdBatiment(entity.getIdBatiment());
+        dto.setNom(entity.getNom());
+        dto.setAdresse(entity.getAdresse());
+        return dto;
+    }
+
+    private void applyDtoToEntity(ChapitreDto dto, Chapitre entity) {
+        entity.setIdBatiment(dto.getIdBatiment());
+        entity.setNom(dto.getNom());
+        entity.setAdresse(dto.getAdresse());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Chapitre entity linked to Carnet
- implement service, repository and controller for Chapitre
- expose CRUD endpoints for chapters on a carnet

## Testing
- `mvn -q test -DskipTests` *(failed: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2da5b2564832a9891215ff0329ef5