### PR TITLE
Add Equipement entity linked to Chapitre

### DIFF
--- a/src/main/java/com/app/copro/controller/EquipementController.java
+++ b/src/main/java/com/app/copro/controller/EquipementController.java
@@ -1,0 +1,48 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.EquipementDto;
+import com.app.copro.service.EquipementService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class EquipementController {
+
+    private final EquipementService service;
+
+    public EquipementController(EquipementService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/chapitres/{chapitreId}/equipements")
+    public ResponseEntity<EquipementDto> create(@PathVariable Long chapitreId,
+                                                @Valid @RequestBody EquipementDto dto) {
+        EquipementDto created = service.create(chapitreId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/chapitres/{chapitreId}/equipements")
+    public ResponseEntity<List<EquipementDto>> getByChapitre(@PathVariable Long chapitreId) {
+        List<EquipementDto> list = service.getByChapitre(chapitreId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/equipements/{id}")
+    public ResponseEntity<EquipementDto> getById(@PathVariable Long id) {
+        EquipementDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/equipements/{id}")
+    public ResponseEntity<EquipementDto> update(@PathVariable Long id,
+                                                @Valid @RequestBody EquipementDto dto) {
+        EquipementDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/src/main/java/com/app/copro/dto/EquipementDto.java
+++ b/src/main/java/com/app/copro/dto/EquipementDto.java
@@ -1,0 +1,106 @@
+package com.app.copro.dto;
+
+import java.time.LocalDate;
+
+public class EquipementDto {
+
+    private Long id;
+    private String libelle;
+    private String marque;
+    private String reference;
+    private String modele;
+    private String emplacement;
+    private Integer quantite;
+    private LocalDate dateAchat;
+    private LocalDate dateFinGarantie;
+    private String prestataire;
+    private String numeroContrat;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getLibelle() {
+        return libelle;
+    }
+
+    public void setLibelle(String libelle) {
+        this.libelle = libelle;
+    }
+
+    public String getMarque() {
+        return marque;
+    }
+
+    public void setMarque(String marque) {
+        this.marque = marque;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public String getModele() {
+        return modele;
+    }
+
+    public void setModele(String modele) {
+        this.modele = modele;
+    }
+
+    public String getEmplacement() {
+        return emplacement;
+    }
+
+    public void setEmplacement(String emplacement) {
+        this.emplacement = emplacement;
+    }
+
+    public Integer getQuantite() {
+        return quantite;
+    }
+
+    public void setQuantite(Integer quantite) {
+        this.quantite = quantite;
+    }
+
+    public LocalDate getDateAchat() {
+        return dateAchat;
+    }
+
+    public void setDateAchat(LocalDate dateAchat) {
+        this.dateAchat = dateAchat;
+    }
+
+    public LocalDate getDateFinGarantie() {
+        return dateFinGarantie;
+    }
+
+    public void setDateFinGarantie(LocalDate dateFinGarantie) {
+        this.dateFinGarantie = dateFinGarantie;
+    }
+
+    public String getPrestataire() {
+        return prestataire;
+    }
+
+    public void setPrestataire(String prestataire) {
+        this.prestataire = prestataire;
+    }
+
+    public String getNumeroContrat() {
+        return numeroContrat;
+    }
+
+    public void setNumeroContrat(String numeroContrat) {
+        this.numeroContrat = numeroContrat;
+    }
+}

--- a/src/main/java/com/app/copro/exception/EquipementNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/EquipementNotFoundException.java
@@ -1,0 +1,7 @@
+package com.app.copro.exception;
+
+public class EquipementNotFoundException extends RuntimeException {
+    public EquipementNotFoundException(Long id) {
+        super("Equipement not found with id " + id);
+    }
+}

--- a/src/main/java/com/app/copro/model/Chapitre.java
+++ b/src/main/java/com/app/copro/model/Chapitre.java
@@ -3,6 +3,9 @@ package com.app.copro.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "chapitre")
 public class Chapitre {
@@ -22,6 +25,9 @@ public class Chapitre {
     @JoinColumn(name = "carnet_id")
     @JsonIgnore
     private Carnet carnet;
+
+    @OneToMany(mappedBy = "chapitre", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Equipement> equipements = new ArrayList<>();
 
     public Long getId() {
         return id;
@@ -61,6 +67,14 @@ public class Chapitre {
 
     public void setCarnet(Carnet carnet) {
         this.carnet = carnet;
+    }
+
+    public List<Equipement> getEquipements() {
+        return equipements;
+    }
+
+    public void setEquipements(List<Equipement> equipements) {
+        this.equipements = equipements;
     }
 }
 

--- a/src/main/java/com/app/copro/model/Equipement.java
+++ b/src/main/java/com/app/copro/model/Equipement.java
@@ -1,0 +1,135 @@
+package com.app.copro.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "equipement")
+public class Equipement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String libelle;
+    private String marque;
+    private String reference;
+    private String modele;
+    private String emplacement;
+    private Integer quantite;
+
+    @Column(name = "date_achat")
+    private LocalDate dateAchat;
+
+    @Column(name = "date_fin_garantie")
+    private LocalDate dateFinGarantie;
+
+    private String prestataire;
+
+    @Column(name = "numero_contrat")
+    private String numeroContrat;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "chapitre_id")
+    @JsonIgnore
+    private Chapitre chapitre;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getLibelle() {
+        return libelle;
+    }
+
+    public void setLibelle(String libelle) {
+        this.libelle = libelle;
+    }
+
+    public String getMarque() {
+        return marque;
+    }
+
+    public void setMarque(String marque) {
+        this.marque = marque;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public String getModele() {
+        return modele;
+    }
+
+    public void setModele(String modele) {
+        this.modele = modele;
+    }
+
+    public String getEmplacement() {
+        return emplacement;
+    }
+
+    public void setEmplacement(String emplacement) {
+        this.emplacement = emplacement;
+    }
+
+    public Integer getQuantite() {
+        return quantite;
+    }
+
+    public void setQuantite(Integer quantite) {
+        this.quantite = quantite;
+    }
+
+    public LocalDate getDateAchat() {
+        return dateAchat;
+    }
+
+    public void setDateAchat(LocalDate dateAchat) {
+        this.dateAchat = dateAchat;
+    }
+
+    public LocalDate getDateFinGarantie() {
+        return dateFinGarantie;
+    }
+
+    public void setDateFinGarantie(LocalDate dateFinGarantie) {
+        this.dateFinGarantie = dateFinGarantie;
+    }
+
+    public String getPrestataire() {
+        return prestataire;
+    }
+
+    public void setPrestataire(String prestataire) {
+        this.prestataire = prestataire;
+    }
+
+    public String getNumeroContrat() {
+        return numeroContrat;
+    }
+
+    public void setNumeroContrat(String numeroContrat) {
+        this.numeroContrat = numeroContrat;
+    }
+
+    public Chapitre getChapitre() {
+        return chapitre;
+    }
+
+    public void setChapitre(Chapitre chapitre) {
+        this.chapitre = chapitre;
+    }
+}
+

--- a/src/main/java/com/app/copro/repository/EquipementRepository.java
+++ b/src/main/java/com/app/copro/repository/EquipementRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.Equipement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface EquipementRepository extends JpaRepository<Equipement, Long> {
+    List<Equipement> findByChapitreId(Long chapitreId);
+}

--- a/src/main/java/com/app/copro/service/EquipementService.java
+++ b/src/main/java/com/app/copro/service/EquipementService.java
@@ -1,0 +1,86 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.EquipementDto;
+import com.app.copro.exception.EquipementNotFoundException;
+import com.app.copro.model.Chapitre;
+import com.app.copro.model.Equipement;
+import com.app.copro.repository.ChapitreRepository;
+import com.app.copro.repository.EquipementRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class EquipementService {
+
+    private final EquipementRepository repository;
+    private final ChapitreRepository chapitreRepository;
+
+    public EquipementService(EquipementRepository repository, ChapitreRepository chapitreRepository) {
+        this.repository = repository;
+        this.chapitreRepository = chapitreRepository;
+    }
+
+    @Transactional
+    public EquipementDto create(Long chapitreId, EquipementDto dto) {
+        Chapitre chapitre = chapitreRepository.findById(chapitreId)
+                .orElseThrow(() -> new RuntimeException("Chapitre not found"));
+        Equipement entity = new Equipement();
+        applyDtoToEntity(dto, entity);
+        entity.setChapitre(chapitre);
+        Equipement saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<EquipementDto> getByChapitre(Long chapitreId) {
+        return repository.findByChapitreId(chapitreId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public EquipementDto getById(Long id) {
+        Equipement entity = repository.findById(id)
+                .orElseThrow(() -> new EquipementNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public EquipementDto update(Long id, EquipementDto dto) {
+        Equipement entity = repository.findById(id)
+                .orElseThrow(() -> new EquipementNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        Equipement saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    private EquipementDto mapToDto(Equipement entity) {
+        EquipementDto dto = new EquipementDto();
+        dto.setId(entity.getId());
+        dto.setLibelle(entity.getLibelle());
+        dto.setMarque(entity.getMarque());
+        dto.setReference(entity.getReference());
+        dto.setModele(entity.getModele());
+        dto.setEmplacement(entity.getEmplacement());
+        dto.setQuantite(entity.getQuantite());
+        dto.setDateAchat(entity.getDateAchat());
+        dto.setDateFinGarantie(entity.getDateFinGarantie());
+        dto.setPrestataire(entity.getPrestataire());
+        dto.setNumeroContrat(entity.getNumeroContrat());
+        return dto;
+    }
+
+    private void applyDtoToEntity(EquipementDto dto, Equipement entity) {
+        entity.setLibelle(dto.getLibelle());
+        entity.setMarque(dto.getMarque());
+        entity.setReference(dto.getReference());
+        entity.setModele(dto.getModele());
+        entity.setEmplacement(dto.getEmplacement());
+        entity.setQuantite(dto.getQuantite());
+        entity.setDateAchat(dto.getDateAchat());
+        entity.setDateFinGarantie(dto.getDateFinGarantie());
+        entity.setPrestataire(dto.getPrestataire());
+        entity.setNumeroContrat(dto.getNumeroContrat());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce Equipement JPA entity with fields for identification, warranty, and contract details
- link Chapitre to its Equipements and expose CRUD endpoints

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e93019ec832a9228bad2dab5a31e