### PR TITLE
Add maintenance contract entity and APIs

### DIFF
--- a/src/main/java/com/app/copro/controller/ContratMaintenanceController.java
+++ b/src/main/java/com/app/copro/controller/ContratMaintenanceController.java
@@ -1,0 +1,96 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.ContratMaintenanceDto;
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.service.ContratMaintenanceFileService;
+import com.app.copro.service.ContratMaintenanceService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class ContratMaintenanceController {
+
+    private final ContratMaintenanceService service;
+    private final ContratMaintenanceFileService fileService;
+
+    public ContratMaintenanceController(ContratMaintenanceService service, ContratMaintenanceFileService fileService) {
+        this.service = service;
+        this.fileService = fileService;
+    }
+
+    @PostMapping("/equipements/{equipementId}/contrats-maintenance")
+    public ResponseEntity<ContratMaintenanceDto> create(@PathVariable Long equipementId,
+                                                         @Valid @RequestBody ContratMaintenanceDto dto) {
+        ContratMaintenanceDto created = service.create(equipementId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/equipements/{equipementId}/contrats-maintenance/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ContratMaintenanceDto> createWithFile(@PathVariable Long equipementId,
+                                                                 @RequestPart("contrat") @Valid ContratMaintenanceDto dto,
+                                                                 @RequestPart(value = "file", required = false) MultipartFile file) {
+        ContratMaintenanceDto created = service.create(equipementId, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), file);
+            created.setFichierRef(ref);
+        }
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/equipements/{equipementId}/contrats-maintenance")
+    public ResponseEntity<List<ContratMaintenanceDto>> getByEquipement(@PathVariable Long equipementId) {
+        List<ContratMaintenanceDto> list = service.getByEquipement(equipementId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/contrats-maintenance/{id}")
+    public ResponseEntity<ContratMaintenanceDto> getById(@PathVariable Long id) {
+        ContratMaintenanceDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/contrats-maintenance/{id}")
+    public ResponseEntity<ContratMaintenanceDto> update(@PathVariable Long id,
+                                                         @Valid @RequestBody ContratMaintenanceDto dto) {
+        ContratMaintenanceDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @PutMapping(value = "/contrats-maintenance/{id}/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ContratMaintenanceDto> updateWithFile(@PathVariable Long id,
+                                                                 @RequestPart("contrat") @Valid ContratMaintenanceDto dto,
+                                                                 @RequestPart(value = "file", required = false) MultipartFile file) {
+        ContratMaintenanceDto updated = service.update(id, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(updated.getId(), file);
+            updated.setFichierRef(ref);
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/contrats-maintenance/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/contrats-maintenance/{id}/file")
+    public ResponseEntity<String> uploadFile(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+        String ref = fileService.uploadFile(id, file);
+        return ref != null ? ResponseEntity.ok(ref) : ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/contrats-maintenance/{id}/file")
+    public ResponseEntity<FileResponseDto> getFile(@PathVariable Long id) {
+        FileResponseDto file = fileService.getFile(id);
+        return file != null ? ResponseEntity.ok(file) : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/app/copro/dto/ContratMaintenanceDto.java
+++ b/src/main/java/com/app/copro/dto/ContratMaintenanceDto.java
@@ -1,0 +1,113 @@
+package com.app.copro.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public class ContratMaintenanceDto {
+    private Long id;
+
+    @NotBlank
+    private String contrat;
+
+    @NotBlank
+    private String numeroContrat;
+
+    @NotNull
+    private LocalDate dateEffet;
+
+    @NotNull
+    private LocalDate dateEcheance;
+
+    private String localisation;
+
+    private String periodicite;
+
+    @NotBlank
+    private String entreprise;
+
+    private Double montant;
+
+    private String fichierRef;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getContrat() {
+        return contrat;
+    }
+
+    public void setContrat(String contrat) {
+        this.contrat = contrat;
+    }
+
+    public String getNumeroContrat() {
+        return numeroContrat;
+    }
+
+    public void setNumeroContrat(String numeroContrat) {
+        this.numeroContrat = numeroContrat;
+    }
+
+    public LocalDate getDateEffet() {
+        return dateEffet;
+    }
+
+    public void setDateEffet(LocalDate dateEffet) {
+        this.dateEffet = dateEffet;
+    }
+
+    public LocalDate getDateEcheance() {
+        return dateEcheance;
+    }
+
+    public void setDateEcheance(LocalDate dateEcheance) {
+        this.dateEcheance = dateEcheance;
+    }
+
+    public String getLocalisation() {
+        return localisation;
+    }
+
+    public void setLocalisation(String localisation) {
+        this.localisation = localisation;
+    }
+
+    public String getPeriodicite() {
+        return periodicite;
+    }
+
+    public void setPeriodicite(String periodicite) {
+        this.periodicite = periodicite;
+    }
+
+    public String getEntreprise() {
+        return entreprise;
+    }
+
+    public void setEntreprise(String entreprise) {
+        this.entreprise = entreprise;
+    }
+
+    public Double getMontant() {
+        return montant;
+    }
+
+    public void setMontant(Double montant) {
+        this.montant = montant;
+    }
+
+    public String getFichierRef() {
+        return fichierRef;
+    }
+
+    public void setFichierRef(String fichierRef) {
+        this.fichierRef = fichierRef;
+    }
+}

--- a/src/main/java/com/app/copro/exception/ContratMaintenanceNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/ContratMaintenanceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.app.copro.exception;
+
+public class ContratMaintenanceNotFoundException extends RuntimeException {
+    public ContratMaintenanceNotFoundException(Long id) {
+        super("Contrat maintenance not found with id " + id);
+    }
+}

--- a/src/main/java/com/app/copro/model/ContratMaintenance.java
+++ b/src/main/java/com/app/copro/model/ContratMaintenance.java
@@ -1,0 +1,149 @@
+package com.app.copro.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+/**
+ * Contrat d'entretien et maintenance des équipements communs.
+ */
+@Entity
+@Table(name = "contrat_maintenance")
+public class ContratMaintenance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Nom du contrat. */
+    @Column(nullable = false)
+    private String contrat;
+
+    /** Numéro de contrat. */
+    @Column(name = "numero_contrat", nullable = false)
+    private String numeroContrat;
+
+    /** Date d'effet. */
+    @Column(name = "date_effet", nullable = false)
+    private LocalDate dateEffet;
+
+    /** Date d'échéance. */
+    @Column(name = "date_echeance", nullable = false)
+    private LocalDate dateEcheance;
+
+    /** Localisation concernée par le contrat. */
+    private String localisation;
+
+    /** Périodicité du contrat. */
+    private String periodicite;
+
+    /** Entreprise prestataire. */
+    @Column(nullable = false)
+    private String entreprise;
+
+    /** Montant du contrat. */
+    private Double montant;
+
+    /** Référence du fichier associé. */
+    @Column(length = 255)
+    private String fichierRef;
+
+    /**
+     * Equipement concerné par ce contrat.
+     */
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "equipement_id")
+    @JsonIgnore
+    private Equipement equipement;
+
+    // ===== Getters/Setters =====
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getContrat() {
+        return contrat;
+    }
+
+    public void setContrat(String contrat) {
+        this.contrat = contrat;
+    }
+
+    public String getNumeroContrat() {
+        return numeroContrat;
+    }
+
+    public void setNumeroContrat(String numeroContrat) {
+        this.numeroContrat = numeroContrat;
+    }
+
+    public LocalDate getDateEffet() {
+        return dateEffet;
+    }
+
+    public void setDateEffet(LocalDate dateEffet) {
+        this.dateEffet = dateEffet;
+    }
+
+    public LocalDate getDateEcheance() {
+        return dateEcheance;
+    }
+
+    public void setDateEcheance(LocalDate dateEcheance) {
+        this.dateEcheance = dateEcheance;
+    }
+
+    public String getLocalisation() {
+        return localisation;
+    }
+
+    public void setLocalisation(String localisation) {
+        this.localisation = localisation;
+    }
+
+    public String getPeriodicite() {
+        return periodicite;
+    }
+
+    public void setPeriodicite(String periodicite) {
+        this.periodicite = periodicite;
+    }
+
+    public String getEntreprise() {
+        return entreprise;
+    }
+
+    public void setEntreprise(String entreprise) {
+        this.entreprise = entreprise;
+    }
+
+    public Double getMontant() {
+        return montant;
+    }
+
+    public void setMontant(Double montant) {
+        this.montant = montant;
+    }
+
+    public String getFichierRef() {
+        return fichierRef;
+    }
+
+    public void setFichierRef(String fichierRef) {
+        this.fichierRef = fichierRef;
+    }
+
+    public Equipement getEquipement() {
+        return equipement;
+    }
+
+    public void setEquipement(Equipement equipement) {
+        this.equipement = equipement;
+    }
+}
+

--- a/src/main/java/com/app/copro/model/Equipement.java
+++ b/src/main/java/com/app/copro/model/Equipement.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "equipement")
@@ -35,6 +37,10 @@ public class Equipement {
     @JoinColumn(name = "chapitre_id")
     @JsonIgnore
     private Chapitre chapitre;
+
+    // 1-N Contrats de maintenance (FK côté ContratMaintenance)
+    @OneToMany(mappedBy = "equipement", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ContratMaintenance> contratsMaintenance = new ArrayList<>();
 
     public Long getId() {
         return id;
@@ -130,6 +136,14 @@ public class Equipement {
 
     public void setChapitre(Chapitre chapitre) {
         this.chapitre = chapitre;
+    }
+
+    public List<ContratMaintenance> getContratsMaintenance() {
+        return contratsMaintenance;
+    }
+
+    public void setContratsMaintenance(List<ContratMaintenance> contratsMaintenance) {
+        this.contratsMaintenance = contratsMaintenance;
     }
 }
 

--- a/src/main/java/com/app/copro/repository/ContratMaintenanceRepository.java
+++ b/src/main/java/com/app/copro/repository/ContratMaintenanceRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.ContratMaintenance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ContratMaintenanceRepository extends JpaRepository<ContratMaintenance, Long> {
+    List<ContratMaintenance> findByEquipementId(Long equipementId);
+}

--- a/src/main/java/com/app/copro/service/ContratMaintenanceFileService.java
+++ b/src/main/java/com/app/copro/service/ContratMaintenanceFileService.java
@@ -1,0 +1,48 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.exception.ContratMaintenanceNotFoundException;
+import com.app.copro.model.ContratMaintenance;
+import com.app.copro.repository.ContratMaintenanceRepository;
+import com.app.copro.util.FileConstants;
+import com.app.copro.util.FileManagerHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+public class ContratMaintenanceFileService {
+
+    @Autowired
+    private FileManagerHelper fileManagerHelper;
+
+    @Autowired
+    private ContratMaintenanceRepository repository;
+
+    public String uploadFile(Long contratId, MultipartFile file) {
+        ContratMaintenance contrat = repository.findById(contratId)
+                .orElseThrow(() -> new ContratMaintenanceNotFoundException(contratId));
+
+        String fileRef = fileManagerHelper.uploadEntityDocument(
+                file,
+                FileConstants.EntityTypes.CONTRAT_MAINTENANCE,
+                contrat.getId(),
+                FileConstants.CommonCategories.CONTRAT,
+                "Document contrat maintenance"
+        );
+
+        if (fileRef != null) {
+            contrat.setFichierRef(fileRef);
+            repository.save(contrat);
+        }
+
+        return fileRef;
+    }
+
+    public FileResponseDto getFile(Long contratId) {
+        Optional<ContratMaintenance> contratOpt = repository.findById(contratId);
+        return contratOpt.map(c -> fileManagerHelper.parseFileReference(c.getFichierRef())).orElse(null);
+    }
+}

--- a/src/main/java/com/app/copro/service/ContratMaintenanceService.java
+++ b/src/main/java/com/app/copro/service/ContratMaintenanceService.java
@@ -1,0 +1,92 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.ContratMaintenanceDto;
+import com.app.copro.exception.ContratMaintenanceNotFoundException;
+import com.app.copro.model.ContratMaintenance;
+import com.app.copro.model.Equipement;
+import com.app.copro.repository.ContratMaintenanceRepository;
+import com.app.copro.repository.EquipementRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ContratMaintenanceService {
+
+    private final ContratMaintenanceRepository repository;
+    private final EquipementRepository equipementRepository;
+
+    public ContratMaintenanceService(ContratMaintenanceRepository repository, EquipementRepository equipementRepository) {
+        this.repository = repository;
+        this.equipementRepository = equipementRepository;
+    }
+
+    @Transactional
+    public ContratMaintenanceDto create(Long equipementId, ContratMaintenanceDto dto) {
+        Equipement equipement = equipementRepository.findById(equipementId)
+                .orElseThrow(() -> new RuntimeException("Equipement not found"));
+        ContratMaintenance entity = new ContratMaintenance();
+        applyDtoToEntity(dto, entity);
+        entity.setEquipement(equipement);
+        ContratMaintenance saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<ContratMaintenanceDto> getByEquipement(Long equipementId) {
+        return repository.findByEquipementId(equipementId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public ContratMaintenanceDto getById(Long id) {
+        ContratMaintenance entity = repository.findById(id)
+                .orElseThrow(() -> new ContratMaintenanceNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public ContratMaintenanceDto update(Long id, ContratMaintenanceDto dto) {
+        ContratMaintenance entity = repository.findById(id)
+                .orElseThrow(() -> new ContratMaintenanceNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        ContratMaintenance saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new ContratMaintenanceNotFoundException(id);
+        }
+        repository.deleteById(id);
+    }
+
+    private ContratMaintenanceDto mapToDto(ContratMaintenance entity) {
+        ContratMaintenanceDto dto = new ContratMaintenanceDto();
+        dto.setId(entity.getId());
+        dto.setContrat(entity.getContrat());
+        dto.setNumeroContrat(entity.getNumeroContrat());
+        dto.setDateEffet(entity.getDateEffet());
+        dto.setDateEcheance(entity.getDateEcheance());
+        dto.setLocalisation(entity.getLocalisation());
+        dto.setPeriodicite(entity.getPeriodicite());
+        dto.setEntreprise(entity.getEntreprise());
+        dto.setMontant(entity.getMontant());
+        dto.setFichierRef(entity.getFichierRef());
+        return dto;
+    }
+
+    private void applyDtoToEntity(ContratMaintenanceDto dto, ContratMaintenance entity) {
+        entity.setContrat(dto.getContrat());
+        entity.setNumeroContrat(dto.getNumeroContrat());
+        entity.setDateEffet(dto.getDateEffet());
+        entity.setDateEcheance(dto.getDateEcheance());
+        entity.setLocalisation(dto.getLocalisation());
+        entity.setPeriodicite(dto.getPeriodicite());
+        entity.setEntreprise(dto.getEntreprise());
+        entity.setMontant(dto.getMontant());
+        entity.setFichierRef(dto.getFichierRef());
+    }
+}

--- a/src/main/java/com/app/copro/util/FileConstants.java
+++ b/src/main/java/com/app/copro/util/FileConstants.java
@@ -15,6 +15,7 @@ public final class FileConstants {
         public static final String TRAVAIL_IMPORTANT = "TRAVAIL_IMPORTANT";
         public static final String PROCEDURE_ADMINISTRATIVE = "PROCEDURE_ADMINISTRATIVE";
         public static final String PPT = "PPT";
+        public static final String CONTRAT_MAINTENANCE = "CONTRAT_MAINTENANCE";
     }
 
     public static final class SyndicCategories {


### PR DESCRIPTION
## Summary
- add ContratMaintenance entity linked to Equipement
- implement CRUD endpoints and file handling for maintenance contracts
- register new entity type for file management

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f3b56ae4832aa79861436e513ac7