### PR TITLE
feat: add interventions and repair works entities

### DIFF
--- a/src/main/java/com/app/copro/controller/InterventionController.java
+++ b/src/main/java/com/app/copro/controller/InterventionController.java
@@ -1,0 +1,96 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.dto.InterventionDto;
+import com.app.copro.service.InterventionFileService;
+import com.app.copro.service.InterventionService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class InterventionController {
+
+    private final InterventionService service;
+    private final InterventionFileService fileService;
+
+    public InterventionController(InterventionService service, InterventionFileService fileService) {
+        this.service = service;
+        this.fileService = fileService;
+    }
+
+    @PostMapping("/equipements/{equipementId}/interventions")
+    public ResponseEntity<InterventionDto> create(@PathVariable Long equipementId,
+                                                  @Valid @RequestBody InterventionDto dto) {
+        InterventionDto created = service.create(equipementId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/equipements/{equipementId}/interventions/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<InterventionDto> createWithFile(@PathVariable Long equipementId,
+                                                          @RequestPart("intervention") @Valid InterventionDto dto,
+                                                          @RequestPart(value = "file", required = false) MultipartFile file) {
+        InterventionDto created = service.create(equipementId, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), file);
+            created.setFichierRef(ref);
+        }
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/equipements/{equipementId}/interventions")
+    public ResponseEntity<List<InterventionDto>> getByEquipement(@PathVariable Long equipementId) {
+        List<InterventionDto> list = service.getByEquipement(equipementId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/interventions/{id}")
+    public ResponseEntity<InterventionDto> getById(@PathVariable Long id) {
+        InterventionDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/interventions/{id}")
+    public ResponseEntity<InterventionDto> update(@PathVariable Long id,
+                                                  @Valid @RequestBody InterventionDto dto) {
+        InterventionDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @PutMapping(value = "/interventions/{id}/with-file", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<InterventionDto> updateWithFile(@PathVariable Long id,
+                                                          @RequestPart("intervention") @Valid InterventionDto dto,
+                                                          @RequestPart(value = "file", required = false) MultipartFile file) {
+        InterventionDto updated = service.update(id, dto);
+        if (file != null && !file.isEmpty()) {
+            String ref = fileService.uploadFile(updated.getId(), file);
+            updated.setFichierRef(ref);
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/interventions/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/interventions/{id}/file")
+    public ResponseEntity<String> uploadFile(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+        String ref = fileService.uploadFile(id, file);
+        return ref != null ? ResponseEntity.ok(ref) : ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/interventions/{id}/file")
+    public ResponseEntity<FileResponseDto> getFile(@PathVariable Long id) {
+        FileResponseDto file = fileService.getFile(id);
+        return file != null ? ResponseEntity.ok(file) : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/app/copro/controller/TravauxReparationController.java
+++ b/src/main/java/com/app/copro/controller/TravauxReparationController.java
@@ -1,0 +1,129 @@
+package com.app.copro.controller;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.dto.TravauxReparationDto;
+import com.app.copro.service.TravauxReparationFileService;
+import com.app.copro.service.TravauxReparationService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@CrossOrigin(origins = "*")
+public class TravauxReparationController {
+
+    private final TravauxReparationService service;
+    private final TravauxReparationFileService fileService;
+
+    public TravauxReparationController(TravauxReparationService service, TravauxReparationFileService fileService) {
+        this.service = service;
+        this.fileService = fileService;
+    }
+
+    @PostMapping("/equipements/{equipementId}/travaux-reparations")
+    public ResponseEntity<TravauxReparationDto> create(@PathVariable Long equipementId,
+                                                       @Valid @RequestBody TravauxReparationDto dto) {
+        TravauxReparationDto created = service.create(equipementId, dto);
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @PostMapping(value = "/equipements/{equipementId}/travaux-reparations/with-files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<TravauxReparationDto> createWithFiles(@PathVariable Long equipementId,
+                                                                @RequestPart("travaux") @Valid TravauxReparationDto dto,
+                                                                @RequestPart(value = "devis", required = false) MultipartFile devis,
+                                                                @RequestPart(value = "facture", required = false) MultipartFile facture,
+                                                                @RequestPart(value = "photoAvant", required = false) MultipartFile photoAvant,
+                                                                @RequestPart(value = "photoApres", required = false) MultipartFile photoApres) {
+        TravauxReparationDto created = service.create(equipementId, dto);
+        if (devis != null && !devis.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), devis, "devis");
+            created.setDevisRef(ref);
+        }
+        if (facture != null && !facture.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), facture, "facture");
+            created.setFactureRef(ref);
+        }
+        if (photoAvant != null && !photoAvant.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), photoAvant, "photoAvant");
+            created.setPhotoAvantRef(ref);
+        }
+        if (photoApres != null && !photoApres.isEmpty()) {
+            String ref = fileService.uploadFile(created.getId(), photoApres, "photoApres");
+            created.setPhotoApresRef(ref);
+        }
+        return new ResponseEntity<>(created, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/equipements/{equipementId}/travaux-reparations")
+    public ResponseEntity<List<TravauxReparationDto>> getByEquipement(@PathVariable Long equipementId) {
+        List<TravauxReparationDto> list = service.getByEquipement(equipementId);
+        return ResponseEntity.ok(list);
+    }
+
+    @GetMapping("/travaux-reparations/{id}")
+    public ResponseEntity<TravauxReparationDto> getById(@PathVariable Long id) {
+        TravauxReparationDto dto = service.getById(id);
+        return ResponseEntity.ok(dto);
+    }
+
+    @PutMapping("/travaux-reparations/{id}")
+    public ResponseEntity<TravauxReparationDto> update(@PathVariable Long id,
+                                                       @Valid @RequestBody TravauxReparationDto dto) {
+        TravauxReparationDto updated = service.update(id, dto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @PutMapping(value = "/travaux-reparations/{id}/with-files", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<TravauxReparationDto> updateWithFiles(@PathVariable Long id,
+                                                                @RequestPart("travaux") @Valid TravauxReparationDto dto,
+                                                                @RequestPart(value = "devis", required = false) MultipartFile devis,
+                                                                @RequestPart(value = "facture", required = false) MultipartFile facture,
+                                                                @RequestPart(value = "photoAvant", required = false) MultipartFile photoAvant,
+                                                                @RequestPart(value = "photoApres", required = false) MultipartFile photoApres) {
+        TravauxReparationDto updated = service.update(id, dto);
+        if (devis != null && !devis.isEmpty()) {
+            String ref = fileService.uploadFile(updated.getId(), devis, "devis");
+            updated.setDevisRef(ref);
+        }
+        if (facture != null && !facture.isEmpty()) {
+            String ref = fileService.uploadFile(updated.getId(), facture, "facture");
+            updated.setFactureRef(ref);
+        }
+        if (photoAvant != null && !photoAvant.isEmpty()) {
+            String ref = fileService.uploadFile(updated.getId(), photoAvant, "photoAvant");
+            updated.setPhotoAvantRef(ref);
+        }
+        if (photoApres != null && !photoApres.isEmpty()) {
+            String ref = fileService.uploadFile(updated.getId(), photoApres, "photoApres");
+            updated.setPhotoApresRef(ref);
+        }
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/travaux-reparations/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/travaux-reparations/{id}/file")
+    public ResponseEntity<String> uploadFile(@PathVariable Long id,
+                                             @RequestParam("type") String type,
+                                             @RequestParam("file") MultipartFile file) {
+        String ref = fileService.uploadFile(id, file, type);
+        return ref != null ? ResponseEntity.ok(ref) : ResponseEntity.badRequest().build();
+    }
+
+    @GetMapping("/travaux-reparations/{id}/file")
+    public ResponseEntity<FileResponseDto> getFile(@PathVariable Long id,
+                                                   @RequestParam("type") String type) {
+        FileResponseDto file = fileService.getFile(id, type);
+        return file != null ? ResponseEntity.ok(file) : ResponseEntity.notFound().build();
+    }
+}

--- a/src/main/java/com/app/copro/dto/InterventionDto.java
+++ b/src/main/java/com/app/copro/dto/InterventionDto.java
@@ -1,0 +1,86 @@
+package com.app.copro.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public class InterventionDto {
+    private Long id;
+
+    @NotBlank
+    private String natureIntervention;
+
+    @NotNull
+    private LocalDate date;
+
+    private Double montant;
+    private String fournisseur;
+    private String observation;
+    private String avancement;
+    private String fichierRef;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNatureIntervention() {
+        return natureIntervention;
+    }
+
+    public void setNatureIntervention(String natureIntervention) {
+        this.natureIntervention = natureIntervention;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public Double getMontant() {
+        return montant;
+    }
+
+    public void setMontant(Double montant) {
+        this.montant = montant;
+    }
+
+    public String getFournisseur() {
+        return fournisseur;
+    }
+
+    public void setFournisseur(String fournisseur) {
+        this.fournisseur = fournisseur;
+    }
+
+    public String getObservation() {
+        return observation;
+    }
+
+    public void setObservation(String observation) {
+        this.observation = observation;
+    }
+
+    public String getAvancement() {
+        return avancement;
+    }
+
+    public void setAvancement(String avancement) {
+        this.avancement = avancement;
+    }
+
+    public String getFichierRef() {
+        return fichierRef;
+    }
+
+    public void setFichierRef(String fichierRef) {
+        this.fichierRef = fichierRef;
+    }
+}

--- a/src/main/java/com/app/copro/dto/TravauxReparationDto.java
+++ b/src/main/java/com/app/copro/dto/TravauxReparationDto.java
@@ -1,0 +1,124 @@
+package com.app.copro.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDate;
+
+public class TravauxReparationDto {
+    private Long id;
+
+    @NotBlank
+    private String typeTravaux;
+
+    @NotBlank
+    private String description;
+
+    private LocalDate dateRealisation;
+
+    @NotBlank
+    private String entreprisePrestataire;
+
+    private Double montantFinal;
+    private String observations;
+    private String avancement;
+    private String devisRef;
+    private String factureRef;
+    private String photoAvantRef;
+    private String photoApresRef;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTypeTravaux() {
+        return typeTravaux;
+    }
+
+    public void setTypeTravaux(String typeTravaux) {
+        this.typeTravaux = typeTravaux;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDate getDateRealisation() {
+        return dateRealisation;
+    }
+
+    public void setDateRealisation(LocalDate dateRealisation) {
+        this.dateRealisation = dateRealisation;
+    }
+
+    public String getEntreprisePrestataire() {
+        return entreprisePrestataire;
+    }
+
+    public void setEntreprisePrestataire(String entreprisePrestataire) {
+        this.entreprisePrestataire = entreprisePrestataire;
+    }
+
+    public Double getMontantFinal() {
+        return montantFinal;
+    }
+
+    public void setMontantFinal(Double montantFinal) {
+        this.montantFinal = montantFinal;
+    }
+
+    public String getObservations() {
+        return observations;
+    }
+
+    public void setObservations(String observations) {
+        this.observations = observations;
+    }
+
+    public String getAvancement() {
+        return avancement;
+    }
+
+    public void setAvancement(String avancement) {
+        this.avancement = avancement;
+    }
+
+    public String getDevisRef() {
+        return devisRef;
+    }
+
+    public void setDevisRef(String devisRef) {
+        this.devisRef = devisRef;
+    }
+
+    public String getFactureRef() {
+        return factureRef;
+    }
+
+    public void setFactureRef(String factureRef) {
+        this.factureRef = factureRef;
+    }
+
+    public String getPhotoAvantRef() {
+        return photoAvantRef;
+    }
+
+    public void setPhotoAvantRef(String photoAvantRef) {
+        this.photoAvantRef = photoAvantRef;
+    }
+
+    public String getPhotoApresRef() {
+        return photoApresRef;
+    }
+
+    public void setPhotoApresRef(String photoApresRef) {
+        this.photoApresRef = photoApresRef;
+    }
+}

--- a/src/main/java/com/app/copro/exception/InterventionNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/InterventionNotFoundException.java
@@ -1,0 +1,7 @@
+package com.app.copro.exception;
+
+public class InterventionNotFoundException extends RuntimeException {
+    public InterventionNotFoundException(Long id) {
+        super("Intervention not found with id " + id);
+    }
+}

--- a/src/main/java/com/app/copro/exception/TravauxReparationNotFoundException.java
+++ b/src/main/java/com/app/copro/exception/TravauxReparationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.app.copro.exception;
+
+public class TravauxReparationNotFoundException extends RuntimeException {
+    public TravauxReparationNotFoundException(Long id) {
+        super("Travaux reparation not found with id " + id);
+    }
+}

--- a/src/main/java/com/app/copro/model/Equipement.java
+++ b/src/main/java/com/app/copro/model/Equipement.java
@@ -42,6 +42,14 @@ public class Equipement {
     @OneToMany(mappedBy = "equipement", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ContratMaintenance> contratsMaintenance = new ArrayList<>();
 
+    // 1-N Interventions
+    @OneToMany(mappedBy = "equipement", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Intervention> interventions = new ArrayList<>();
+
+    // 1-N Travaux de réparation et de remplacement
+    @OneToMany(mappedBy = "equipement", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TravauxReparation> travauxReparations = new ArrayList<>();
+
     public Long getId() {
         return id;
     }
@@ -144,6 +152,22 @@ public class Equipement {
 
     public void setContratsMaintenance(List<ContratMaintenance> contratsMaintenance) {
         this.contratsMaintenance = contratsMaintenance;
+    }
+
+    public List<Intervention> getInterventions() {
+        return interventions;
+    }
+
+    public void setInterventions(List<Intervention> interventions) {
+        this.interventions = interventions;
+    }
+
+    public List<TravauxReparation> getTravauxReparations() {
+        return travauxReparations;
+    }
+
+    public void setTravauxReparations(List<TravauxReparation> travauxReparations) {
+        this.travauxReparations = travauxReparations;
     }
 }
 

--- a/src/main/java/com/app/copro/model/Intervention.java
+++ b/src/main/java/com/app/copro/model/Intervention.java
@@ -1,0 +1,110 @@
+package com.app.copro.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "intervention")
+public class Intervention {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nature_intervention", nullable = false)
+    private String natureIntervention;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    private Double montant;
+
+    private String fournisseur;
+
+    @Column(columnDefinition = "TEXT")
+    private String observation;
+
+    private String avancement;
+
+    @Column(length = 255)
+    private String fichierRef;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "equipement_id")
+    @JsonIgnore
+    private Equipement equipement;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNatureIntervention() {
+        return natureIntervention;
+    }
+
+    public void setNatureIntervention(String natureIntervention) {
+        this.natureIntervention = natureIntervention;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public Double getMontant() {
+        return montant;
+    }
+
+    public void setMontant(Double montant) {
+        this.montant = montant;
+    }
+
+    public String getFournisseur() {
+        return fournisseur;
+    }
+
+    public void setFournisseur(String fournisseur) {
+        this.fournisseur = fournisseur;
+    }
+
+    public String getObservation() {
+        return observation;
+    }
+
+    public void setObservation(String observation) {
+        this.observation = observation;
+    }
+
+    public String getAvancement() {
+        return avancement;
+    }
+
+    public void setAvancement(String avancement) {
+        this.avancement = avancement;
+    }
+
+    public String getFichierRef() {
+        return fichierRef;
+    }
+
+    public void setFichierRef(String fichierRef) {
+        this.fichierRef = fichierRef;
+    }
+
+    public Equipement getEquipement() {
+        return equipement;
+    }
+
+    public void setEquipement(Equipement equipement) {
+        this.equipement = equipement;
+    }
+}

--- a/src/main/java/com/app/copro/model/TravauxReparation.java
+++ b/src/main/java/com/app/copro/model/TravauxReparation.java
@@ -1,0 +1,155 @@
+package com.app.copro.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "travaux_reparation")
+public class TravauxReparation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "type_travaux", nullable = false)
+    private String typeTravaux;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "date_realisation")
+    private LocalDate dateRealisation;
+
+    @Column(name = "entreprise_prestataire", nullable = false)
+    private String entreprisePrestataire;
+
+    private Double montantFinal;
+
+    @Column(columnDefinition = "TEXT")
+    private String observations;
+
+    private String avancement;
+
+    @Column(length = 255)
+    private String devisRef;
+
+    @Column(length = 255)
+    private String factureRef;
+
+    @Column(length = 255)
+    private String photoAvantRef;
+
+    @Column(length = 255)
+    private String photoApresRef;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "equipement_id")
+    @JsonIgnore
+    private Equipement equipement;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTypeTravaux() {
+        return typeTravaux;
+    }
+
+    public void setTypeTravaux(String typeTravaux) {
+        this.typeTravaux = typeTravaux;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDate getDateRealisation() {
+        return dateRealisation;
+    }
+
+    public void setDateRealisation(LocalDate dateRealisation) {
+        this.dateRealisation = dateRealisation;
+    }
+
+    public String getEntreprisePrestataire() {
+        return entreprisePrestataire;
+    }
+
+    public void setEntreprisePrestataire(String entreprisePrestataire) {
+        this.entreprisePrestataire = entreprisePrestataire;
+    }
+
+    public Double getMontantFinal() {
+        return montantFinal;
+    }
+
+    public void setMontantFinal(Double montantFinal) {
+        this.montantFinal = montantFinal;
+    }
+
+    public String getObservations() {
+        return observations;
+    }
+
+    public void setObservations(String observations) {
+        this.observations = observations;
+    }
+
+    public String getAvancement() {
+        return avancement;
+    }
+
+    public void setAvancement(String avancement) {
+        this.avancement = avancement;
+    }
+
+    public String getDevisRef() {
+        return devisRef;
+    }
+
+    public void setDevisRef(String devisRef) {
+        this.devisRef = devisRef;
+    }
+
+    public String getFactureRef() {
+        return factureRef;
+    }
+
+    public void setFactureRef(String factureRef) {
+        this.factureRef = factureRef;
+    }
+
+    public String getPhotoAvantRef() {
+        return photoAvantRef;
+    }
+
+    public void setPhotoAvantRef(String photoAvantRef) {
+        this.photoAvantRef = photoAvantRef;
+    }
+
+    public String getPhotoApresRef() {
+        return photoApresRef;
+    }
+
+    public void setPhotoApresRef(String photoApresRef) {
+        this.photoApresRef = photoApresRef;
+    }
+
+    public Equipement getEquipement() {
+        return equipement;
+    }
+
+    public void setEquipement(Equipement equipement) {
+        this.equipement = equipement;
+    }
+}

--- a/src/main/java/com/app/copro/repository/InterventionRepository.java
+++ b/src/main/java/com/app/copro/repository/InterventionRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.Intervention;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InterventionRepository extends JpaRepository<Intervention, Long> {
+    List<Intervention> findByEquipementId(Long equipementId);
+}

--- a/src/main/java/com/app/copro/repository/TravauxReparationRepository.java
+++ b/src/main/java/com/app/copro/repository/TravauxReparationRepository.java
@@ -1,0 +1,10 @@
+package com.app.copro.repository;
+
+import com.app.copro.model.TravauxReparation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TravauxReparationRepository extends JpaRepository<TravauxReparation, Long> {
+    List<TravauxReparation> findByEquipementId(Long equipementId);
+}

--- a/src/main/java/com/app/copro/service/InterventionFileService.java
+++ b/src/main/java/com/app/copro/service/InterventionFileService.java
@@ -1,0 +1,48 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.exception.InterventionNotFoundException;
+import com.app.copro.model.Intervention;
+import com.app.copro.repository.InterventionRepository;
+import com.app.copro.util.FileConstants;
+import com.app.copro.util.FileManagerHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+public class InterventionFileService {
+
+    @Autowired
+    private FileManagerHelper fileManagerHelper;
+
+    @Autowired
+    private InterventionRepository repository;
+
+    public String uploadFile(Long interventionId, MultipartFile file) {
+        Intervention intervention = repository.findById(interventionId)
+                .orElseThrow(() -> new InterventionNotFoundException(interventionId));
+
+        String fileRef = fileManagerHelper.uploadEntityDocument(
+                file,
+                FileConstants.EntityTypes.INTERVENTION,
+                intervention.getId(),
+                FileConstants.CommonCategories.DOCUMENT,
+                "Document intervention"
+        );
+
+        if (fileRef != null) {
+            intervention.setFichierRef(fileRef);
+            repository.save(intervention);
+        }
+
+        return fileRef;
+    }
+
+    public FileResponseDto getFile(Long interventionId) {
+        Optional<Intervention> opt = repository.findById(interventionId);
+        return opt.map(i -> fileManagerHelper.parseFileReference(i.getFichierRef())).orElse(null);
+    }
+}

--- a/src/main/java/com/app/copro/service/InterventionService.java
+++ b/src/main/java/com/app/copro/service/InterventionService.java
@@ -1,0 +1,88 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.InterventionDto;
+import com.app.copro.exception.InterventionNotFoundException;
+import com.app.copro.model.Equipement;
+import com.app.copro.model.Intervention;
+import com.app.copro.repository.EquipementRepository;
+import com.app.copro.repository.InterventionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class InterventionService {
+
+    private final InterventionRepository repository;
+    private final EquipementRepository equipementRepository;
+
+    public InterventionService(InterventionRepository repository, EquipementRepository equipementRepository) {
+        this.repository = repository;
+        this.equipementRepository = equipementRepository;
+    }
+
+    @Transactional
+    public InterventionDto create(Long equipementId, InterventionDto dto) {
+        Equipement equipement = equipementRepository.findById(equipementId)
+                .orElseThrow(() -> new RuntimeException("Equipement not found"));
+        Intervention entity = new Intervention();
+        applyDtoToEntity(dto, entity);
+        entity.setEquipement(equipement);
+        Intervention saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<InterventionDto> getByEquipement(Long equipementId) {
+        return repository.findByEquipementId(equipementId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public InterventionDto getById(Long id) {
+        Intervention entity = repository.findById(id)
+                .orElseThrow(() -> new InterventionNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public InterventionDto update(Long id, InterventionDto dto) {
+        Intervention entity = repository.findById(id)
+                .orElseThrow(() -> new InterventionNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        Intervention saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new InterventionNotFoundException(id);
+        }
+        repository.deleteById(id);
+    }
+
+    private InterventionDto mapToDto(Intervention entity) {
+        InterventionDto dto = new InterventionDto();
+        dto.setId(entity.getId());
+        dto.setNatureIntervention(entity.getNatureIntervention());
+        dto.setDate(entity.getDate());
+        dto.setMontant(entity.getMontant());
+        dto.setFournisseur(entity.getFournisseur());
+        dto.setObservation(entity.getObservation());
+        dto.setAvancement(entity.getAvancement());
+        dto.setFichierRef(entity.getFichierRef());
+        return dto;
+    }
+
+    private void applyDtoToEntity(InterventionDto dto, Intervention entity) {
+        entity.setNatureIntervention(dto.getNatureIntervention());
+        entity.setDate(dto.getDate());
+        entity.setMontant(dto.getMontant());
+        entity.setFournisseur(dto.getFournisseur());
+        entity.setObservation(dto.getObservation());
+        entity.setAvancement(dto.getAvancement());
+        entity.setFichierRef(dto.getFichierRef());
+    }
+}

--- a/src/main/java/com/app/copro/service/TravauxReparationFileService.java
+++ b/src/main/java/com/app/copro/service/TravauxReparationFileService.java
@@ -1,0 +1,91 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.FileResponseDto;
+import com.app.copro.exception.TravauxReparationNotFoundException;
+import com.app.copro.model.TravauxReparation;
+import com.app.copro.repository.TravauxReparationRepository;
+import com.app.copro.util.FileConstants;
+import com.app.copro.util.FileManagerHelper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Service
+public class TravauxReparationFileService {
+
+    @Autowired
+    private FileManagerHelper fileManagerHelper;
+
+    @Autowired
+    private TravauxReparationRepository repository;
+
+    public String uploadFile(Long travauxId, MultipartFile file, String type) {
+        TravauxReparation travaux = repository.findById(travauxId)
+                .orElseThrow(() -> new TravauxReparationNotFoundException(travauxId));
+
+        String category;
+        String description;
+        switch (type) {
+            case "devis" -> {
+                category = FileConstants.CommonCategories.DOCUMENT;
+                description = "Devis travaux";
+            }
+            case "facture" -> {
+                category = FileConstants.CommonCategories.FACTURE;
+                description = "Facture travaux";
+            }
+            case "photoAvant" -> {
+                category = FileConstants.CommonCategories.IMAGE;
+                description = "Photo avant travaux";
+            }
+            case "photoApres" -> {
+                category = FileConstants.CommonCategories.IMAGE;
+                description = "Photo apres travaux";
+            }
+            default -> {
+                return null;
+            }
+        }
+
+        String ref = fileManagerHelper.uploadEntityDocument(
+                file,
+                FileConstants.EntityTypes.TRAVAUX_REPARATION,
+                travaux.getId(),
+                category,
+                description
+        );
+
+        if (ref != null) {
+            switch (type) {
+                case "devis" -> travaux.setDevisRef(ref);
+                case "facture" -> travaux.setFactureRef(ref);
+                case "photoAvant" -> travaux.setPhotoAvantRef(ref);
+                case "photoApres" -> travaux.setPhotoApresRef(ref);
+            }
+            repository.save(travaux);
+        }
+
+        return ref;
+    }
+
+    public FileResponseDto getFile(Long travauxId, String type) {
+        Optional<TravauxReparation> opt = repository.findById(travauxId);
+        if (opt.isEmpty()) {
+            return null;
+        }
+        TravauxReparation travaux = opt.get();
+        String ref;
+        switch (type) {
+            case "devis" -> ref = travaux.getDevisRef();
+            case "facture" -> ref = travaux.getFactureRef();
+            case "photoAvant" -> ref = travaux.getPhotoAvantRef();
+            case "photoApres" -> ref = travaux.getPhotoApresRef();
+            default -> {
+                return null;
+            }
+        }
+        return fileManagerHelper.parseFileReference(ref);
+    }
+}

--- a/src/main/java/com/app/copro/service/TravauxReparationService.java
+++ b/src/main/java/com/app/copro/service/TravauxReparationService.java
@@ -1,0 +1,96 @@
+package com.app.copro.service;
+
+import com.app.copro.dto.TravauxReparationDto;
+import com.app.copro.exception.TravauxReparationNotFoundException;
+import com.app.copro.model.Equipement;
+import com.app.copro.model.TravauxReparation;
+import com.app.copro.repository.EquipementRepository;
+import com.app.copro.repository.TravauxReparationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class TravauxReparationService {
+
+    private final TravauxReparationRepository repository;
+    private final EquipementRepository equipementRepository;
+
+    public TravauxReparationService(TravauxReparationRepository repository, EquipementRepository equipementRepository) {
+        this.repository = repository;
+        this.equipementRepository = equipementRepository;
+    }
+
+    @Transactional
+    public TravauxReparationDto create(Long equipementId, TravauxReparationDto dto) {
+        Equipement equipement = equipementRepository.findById(equipementId)
+                .orElseThrow(() -> new RuntimeException("Equipement not found"));
+        TravauxReparation entity = new TravauxReparation();
+        applyDtoToEntity(dto, entity);
+        entity.setEquipement(equipement);
+        TravauxReparation saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    public List<TravauxReparationDto> getByEquipement(Long equipementId) {
+        return repository.findByEquipementId(equipementId).stream()
+                .map(this::mapToDto)
+                .collect(Collectors.toList());
+    }
+
+    public TravauxReparationDto getById(Long id) {
+        TravauxReparation entity = repository.findById(id)
+                .orElseThrow(() -> new TravauxReparationNotFoundException(id));
+        return mapToDto(entity);
+    }
+
+    @Transactional
+    public TravauxReparationDto update(Long id, TravauxReparationDto dto) {
+        TravauxReparation entity = repository.findById(id)
+                .orElseThrow(() -> new TravauxReparationNotFoundException(id));
+        applyDtoToEntity(dto, entity);
+        TravauxReparation saved = repository.save(entity);
+        return mapToDto(saved);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new TravauxReparationNotFoundException(id);
+        }
+        repository.deleteById(id);
+    }
+
+    private TravauxReparationDto mapToDto(TravauxReparation entity) {
+        TravauxReparationDto dto = new TravauxReparationDto();
+        dto.setId(entity.getId());
+        dto.setTypeTravaux(entity.getTypeTravaux());
+        dto.setDescription(entity.getDescription());
+        dto.setDateRealisation(entity.getDateRealisation());
+        dto.setEntreprisePrestataire(entity.getEntreprisePrestataire());
+        dto.setMontantFinal(entity.getMontantFinal());
+        dto.setObservations(entity.getObservations());
+        dto.setAvancement(entity.getAvancement());
+        dto.setDevisRef(entity.getDevisRef());
+        dto.setFactureRef(entity.getFactureRef());
+        dto.setPhotoAvantRef(entity.getPhotoAvantRef());
+        dto.setPhotoApresRef(entity.getPhotoApresRef());
+        return dto;
+    }
+
+    private void applyDtoToEntity(TravauxReparationDto dto, TravauxReparation entity) {
+        entity.setTypeTravaux(dto.getTypeTravaux());
+        entity.setDescription(dto.getDescription());
+        entity.setDateRealisation(dto.getDateRealisation());
+        entity.setEntreprisePrestataire(dto.getEntreprisePrestataire());
+        entity.setMontantFinal(dto.getMontantFinal());
+        entity.setObservations(dto.getObservations());
+        entity.setAvancement(dto.getAvancement());
+        entity.setDevisRef(dto.getDevisRef());
+        entity.setFactureRef(dto.getFactureRef());
+        entity.setPhotoAvantRef(dto.getPhotoAvantRef());
+        entity.setPhotoApresRef(dto.getPhotoApresRef());
+    }
+}

--- a/src/main/java/com/app/copro/util/FileConstants.java
+++ b/src/main/java/com/app/copro/util/FileConstants.java
@@ -16,6 +16,8 @@ public final class FileConstants {
         public static final String PROCEDURE_ADMINISTRATIVE = "PROCEDURE_ADMINISTRATIVE";
         public static final String PPT = "PPT";
         public static final String CONTRAT_MAINTENANCE = "CONTRAT_MAINTENANCE";
+        public static final String INTERVENTION = "INTERVENTION";
+        public static final String TRAVAUX_REPARATION = "TRAVAUX_REPARATION";
     }
 
     public static final class SyndicCategories {


### PR DESCRIPTION
## Summary
- add `Intervention` entity with CRUD and file upload API
- add `TravauxReparation` entity for repair/replacement works with multiple file uploads
- link new entities to `Equipement` and extend file constants

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f8122760832ab2be4cf066b018a3